### PR TITLE
remove `range` from `GetOptions` for now

### DIFF
--- a/obstore/python/obstore/_get.pyi
+++ b/obstore/python/obstore/_get.pyi
@@ -12,7 +12,7 @@ else:
     from typing_extensions import Buffer as _Buffer
 
 class GetOptions(TypedDict, total=False):
-    """Options for a get request, such as range.
+    """Options for a get request.
 
     All options are optional.
     """
@@ -67,7 +67,7 @@ class GetOptions(TypedDict, total=False):
     <https://datatracker.ietf.org/doc/html/rfc9110#section-13.1.4>
     """
 
-    range: Tuple[int | None, int | None]
+    # range: Tuple[int | None, int | None]
     """
     Request transfer of only the specified range of bytes
     otherwise returning [`Error::NotModified`]
@@ -161,7 +161,7 @@ class GetResult:
         """
 
     @property
-    def range(self) -> ObjectMeta:
+    def range(self) -> Tuple[int, int]:
         """The range of bytes returned by this request.
 
         This must be accessed _before_ calling `stream`, `bytes`, or `bytes_async`.

--- a/obstore/src/get.rs
+++ b/obstore/src/get.rs
@@ -27,7 +27,8 @@ pub(crate) struct PyGetOptions {
     if_none_match: Option<String>,
     if_modified_since: Option<DateTime<Utc>>,
     if_unmodified_since: Option<DateTime<Utc>>,
-    range: Option<PyGetRange>,
+    // Taking out of public API until we can decide the right way to expose this
+    // range: Option<PyGetRange>,
     version: Option<String>,
     head: bool,
 }
@@ -48,7 +49,7 @@ impl<'py> FromPyObject<'py> for PyGetOptions {
                 .get("if_unmodified_since")
                 .map(|x| x.extract())
                 .transpose()?,
-            range: dict.get("range").map(|x| x.extract()).transpose()?,
+            // range: dict.get("range").map(|x| x.extract()).transpose()?,
             version: dict.get("version").map(|x| x.extract()).transpose()?,
             head: dict
                 .get("head")
@@ -66,15 +67,18 @@ impl From<PyGetOptions> for GetOptions {
             if_none_match: value.if_none_match,
             if_modified_since: value.if_modified_since,
             if_unmodified_since: value.if_unmodified_since,
-            range: value.range.map(|x| x.0),
+            range: Default::default(),
             version: value.version,
             head: value.head,
         }
     }
 }
 
+#[allow(dead_code)]
 pub(crate) struct PyGetRange(GetRange);
 
+// TODO: think of a better API here so that the distinction between each of these is easy to
+// understand.
 impl<'py> FromPyObject<'py> for PyGetRange {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let range = ob.extract::<[Option<usize>; 2]>()?;

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -47,6 +47,7 @@ async def test_stream_async():
     assert pos == len(data)
 
 
+@pytest.mark.skip("Skip until we restore range in get_options")
 def test_get_with_options():
     store = MemoryStore()
 


### PR DESCRIPTION
Because of confusion around how `range: Tuple[int | None, int | None]` is interpreted (https://github.com/developmentseed/obstore/pull/40#issuecomment-2433490733, https://github.com/zarr-developers/zarr-python/issues/2437), we'll remove `range` from `GetOptions` for now. 99% of range request cases are handled via `get_range` and `get_ranges`, so this is fine to punt towards the future.

Originally implemented in https://github.com/developmentseed/obstore/pull/40