### PR TITLE
Re-expose `range` in `GetOptions`

### DIFF
--- a/docs/api/get.md
+++ b/docs/api/get.md
@@ -9,3 +9,5 @@
 ::: obstore.GetOptions
 ::: obstore.GetResult
 ::: obstore.Buffer
+::: obstore.OffsetRange
+::: obstore.SuffixRange

--- a/obstore/python/obstore/_obstore.pyi
+++ b/obstore/python/obstore/_obstore.pyi
@@ -10,6 +10,8 @@ from ._delete import delete_async as delete_async
 from ._get import Buffer as Buffer
 from ._get import GetOptions as GetOptions
 from ._get import GetResult as GetResult
+from ._get import OffsetRange as OffsetRange
+from ._get import SuffixRange as SuffixRange
 from ._get import get as get
 from ._get import get_async as get_async
 from ._get import get_range as get_range

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -47,7 +47,6 @@ async def test_stream_async():
     assert pos == len(data)
 
 
-@pytest.mark.skip("Skip until we restore range in get_options")
 def test_get_with_options():
     store = MemoryStore()
 
@@ -60,6 +59,42 @@ def test_get_with_options():
     assert result.range == (5, 10)
     buf = result.bytes()
     assert buf == data[5:10]
+
+    # Test list input
+    result = obs.get(store, path, options={"range": [5, 10]})
+    assert result.range == (5, 10)
+    buf = result.bytes()
+    assert buf == data[5:10]
+
+
+def test_get_with_options_offset():
+    store = MemoryStore()
+
+    data = b"the quick brown fox jumps over the lazy dog," * 100
+    path = "big-data.txt"
+
+    obs.put(store, path, data)
+
+    result = obs.get(store, path, options={"range": {"offset": 100}})
+    result_range = result.range
+    assert result_range == (100, 4400)
+    buf = result.bytes()
+    assert buf == data[result_range[0] : result_range[1]]
+
+
+def test_get_with_options_suffix():
+    store = MemoryStore()
+
+    data = b"the quick brown fox jumps over the lazy dog," * 100
+    path = "big-data.txt"
+
+    obs.put(store, path, data)
+
+    result = obs.get(store, path, options={"range": {"suffix": 100}})
+    result_range = result.range
+    assert result_range == (4300, 4400)
+    buf = result.bytes()
+    assert buf == data[result_range[0] : result_range[1]]
 
 
 def test_get_range():


### PR DESCRIPTION
This was removed from `GetOptions` for the 0.2.0 release in https://github.com/developmentseed/obstore/pull/51.

The semantics are now described in the docstring as:
<img width="701" alt="image" src="https://github.com/user-attachments/assets/a6906446-b0ae-4cca-856b-ce6a13e35f9a">
