### PR TITLE
Standardize on start/end, not offset/length for range requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
+## [0.3.0] -
+
+### Breaking changes
+
+- `get_range`, `get_range_async`, `get_ranges`, and `get_ranges_async` now use **start/end** instead of **offset/length**. This is for consistency with the `range` option of `obstore.get`.
+
 ## [0.2.0] - 2024-10-25
 
-## What's Changed
+### What's Changed
 
 - Streaming list results. `list` now returns an async or sync generator. by @kylebarron in https://github.com/developmentseed/obstore/pull/35
 - Optionally return list result as arrow. The `return_arrow` keyword argument returns chunks from `list` as Arrow RecordBatches, which is faster than materializing Python dicts/lists. by @kylebarron in https://github.com/developmentseed/obstore/pull/38

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "obstore"
-version = "0.3.0-beta.1"
+version = "0.3.0-beta.2"
 dependencies = [
  "arrow",
  "bytes",

--- a/obstore/Cargo.toml
+++ b/obstore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "obstore"
-version = "0.3.0-beta.1"
+version = "0.3.0-beta.2"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "A Python interface to the Rust object_store crate, providing a uniform API for interacting with object storage services and local files."

--- a/obstore/python/obstore/_get.pyi
+++ b/obstore/python/obstore/_get.pyi
@@ -235,7 +235,7 @@ async def get_async(
     Refer to the documentation for [get][obstore.get].
     """
 
-def get_range(store: ObjectStore, path: str, offset: int, length: int) -> Buffer:
+def get_range(store: ObjectStore, path: str, start: int, end: int) -> Buffer:
     """
     Return the bytes that are stored at the specified location in the given byte range.
 
@@ -247,8 +247,8 @@ def get_range(store: ObjectStore, path: str, offset: int, length: int) -> Buffer
     Args:
         store: The ObjectStore instance to use.
         path: The path within ObjectStore to retrieve.
-        offset: The start of the byte range.
-        length: The number of bytes.
+        start: The start of the byte range.
+        end: The end of the byte range (exclusive).
 
     Returns:
         A `Buffer` object implementing the Python buffer protocol, allowing
@@ -256,7 +256,7 @@ def get_range(store: ObjectStore, path: str, offset: int, length: int) -> Buffer
     """
 
 async def get_range_async(
-    store: ObjectStore, path: str, offset: int, length: int
+    store: ObjectStore, path: str, start: int, end: int
 ) -> Buffer:
     """Call `get_range` asynchronously.
 
@@ -264,7 +264,7 @@ async def get_range_async(
     """
 
 def get_ranges(
-    store: ObjectStore, path: str, offsets: Sequence[int], lengths: Sequence[int]
+    store: ObjectStore, path: str, starts: Sequence[int], ends: Sequence[int]
 ) -> List[Buffer]:
     """
     Return the bytes that are stored at the specified location in the given byte ranges
@@ -277,8 +277,8 @@ def get_ranges(
     Args:
         store: The ObjectStore instance to use.
         path: The path within ObjectStore to retrieve.
-        offsets: A sequence of `int` where each offset starts.
-        lengths: A sequence of `int` representing the number of bytes within each range.
+        starts: A sequence of `int` where each offset starts.
+        ends: A sequence of `int` where each offset ends (exclusive).
 
     Returns:
         A sequence of `Buffer`, one for each range. This `Buffer` object implements the
@@ -287,7 +287,7 @@ def get_ranges(
     """
 
 async def get_ranges_async(
-    store: ObjectStore, path: str, offsets: Sequence[int], lengths: Sequence[int]
+    store: ObjectStore, path: str, starts: Sequence[int], ends: Sequence[int]
 ) -> List[Buffer]:
     """Call `get_ranges` asynchronously.
 

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -104,7 +104,7 @@ def test_get_range():
     path = "big-data.txt"
 
     obs.put(store, path, data)
-    buffer = obs.get_range(store, path, 5, 10)
+    buffer = obs.get_range(store, path, 5, 15)
     view = memoryview(buffer)
     assert view == data[5:15]
 
@@ -116,9 +116,9 @@ def test_get_ranges():
     path = "big-data.txt"
 
     obs.put(store, path, data)
-    offsets = [5, 10, 15, 20]
-    lengths = [10, 10, 10, 10]
-    buffers = obs.get_ranges(store, path, offsets, lengths)
+    starts = [5, 10, 15, 20]
+    ends = [15, 20, 25, 30]
+    buffers = obs.get_ranges(store, path, starts, ends)
 
-    for offset, length, buffer in zip(offsets, lengths, buffers):
-        assert memoryview(buffer) == data[offset : offset + length]
+    for start, end, buffer in zip(starts, ends, buffers):
+        assert memoryview(buffer) == data[start:end]


### PR DESCRIPTION
`get_range`, `get_range_async`, `get_ranges`, and `get_ranges_async` now use **start/end** instead of **offset/length**. This is for consistency with the `range` option of `obstore.get`.