### PR TITLE
Raise RuntimeWarning for debug builds

### DIFF
--- a/obstore/src/lib.rs
+++ b/obstore/src/lib.rs
@@ -1,4 +1,7 @@
+use pyo3::exceptions::PyRuntimeWarning;
+use pyo3::intern;
 use pyo3::prelude::*;
+use pyo3::types::PyTuple;
 
 mod attributes;
 mod buffered;
@@ -21,9 +24,27 @@ fn ___version() -> &'static str {
     VERSION
 }
 
+/// Raise RuntimeWarning for debug builds
+#[pyfunction]
+fn check_debug_build(py: Python) -> PyResult<()> {
+    #[cfg(debug_assertions)]
+    {
+        let warnings_mod = py.import_bound(intern!(py, "warnings"))?;
+        let warning = PyRuntimeWarning::new_err(
+            "obstore has not been compiled in release mode. Performance will be degraded.",
+        );
+        let args = PyTuple::new_bound(py, vec![warning.into_py(py)]);
+        warnings_mod.call_method1(intern!(py, "warn"), args)?;
+    }
+
+    Ok(())
+}
+
 /// A Python module implemented in Rust.
 #[pymodule]
 fn _obstore(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
+    check_debug_build(py)?;
+
     m.add_wrapped(wrap_pyfunction!(___version))?;
 
     pyo3_object_store::register_store_module(py, m, "obstore")?;


### PR DESCRIPTION
```
Python 3.11.8 (main, Aug 21 2024, 16:00:03) [Clang 15.0.0 (clang-1500.3.9.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import obstore
<frozen importlib._bootstrap>:241: RuntimeWarning: obstore has not been compiled in release mode. Performance will be degraded.
```

Closes #79 