### PR TITLE
Fix retry dict conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "obstore"
-version = "0.3.0-beta.6"
+version = "0.3.0-beta.7"
 dependencies = [
  "arrow",
  "bytes",

--- a/obstore/Cargo.toml
+++ b/obstore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "obstore"
-version = "0.3.0-beta.6"
+version = "0.3.0-beta.7"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "A Python interface to the Rust object_store crate, providing a uniform API for interacting with object storage services and local files."

--- a/pyo3-object_store/src/retry.rs
+++ b/pyo3-object_store/src/retry.rs
@@ -4,6 +4,7 @@ use object_store::{BackoffConfig, RetryConfig};
 use pyo3::prelude::*;
 
 #[derive(Debug, FromPyObject)]
+#[pyo3(from_item_all)]
 pub struct PyBackoffConfig {
     init_backoff: Duration,
     max_backoff: Duration,
@@ -21,6 +22,7 @@ impl From<PyBackoffConfig> for BackoffConfig {
 }
 
 #[derive(Debug, FromPyObject)]
+#[pyo3(from_item_all)]
 pub struct PyRetryConfig {
     backoff: PyBackoffConfig,
     max_retries: usize,

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -1,0 +1,22 @@
+from datetime import timedelta
+
+from obstore.store import HTTPStore
+
+
+def test_construction_with_backoff_config():
+    _store = HTTPStore.from_url(
+        "https://...",
+        client_options={
+            "connect_timeout": "4 seconds",
+            "timeout": "16 seconds",
+        },
+        retry_config={
+            "max_retries": 10,
+            "backoff": {
+                "base": 2,
+                "init_backoff": timedelta(seconds=1),
+                "max_backoff": timedelta(seconds=16),
+            },
+            "retry_timeout": timedelta(minutes=3),
+        },
+    )


### PR DESCRIPTION
Closes #92 

It's a bit confusing that we have to write timedelta in a string for the `client_options`. https://github.com/developmentseed/obstore/pull/81 may help fix that by adding a `ClientOptions` Python class.

@aldenks You can look at the new test case I added here.