### PR TITLE
Update documentation to include file-like objects and fsspec integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ Simple, fast integration with object storage services like Amazon S3, Google Clo
 - Sync and async API.
 - Streaming downloads with configurable chunking.
 - Streaming `list`, with no need to paginate.
+- File-like object API and [fsspec](https://github.com/fsspec/filesystem_spec) integration.
 - Support for conditional put ("put if not exists"), as well as custom tags and attributes.
-- Automatically supports [multipart uploads](https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html) under the hood for large file objects.
+- Automatically uses [multipart uploads](https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html) under the hood for large file objects.
 - Optionally return list results as [Arrow](https://arrow.apache.org/), which is faster than materializing Python `dict`/`list` objects.
 - Easy to install with no required Python dependencies.
 - The [underlying Rust library](https://docs.rs/object_store) is production quality and used in large scale production systems, such as the Rust package registry [crates.io](https://crates.io/).
@@ -89,6 +90,11 @@ There are a few additional APIs useful for specific use cases:
 - [`get_ranges`](https://developmentseed.org/obstore/latest/api/get/#obstore.get_ranges): Get multiple byte ranges from a single file.
 - [`list_with_delimiter`](https://developmentseed.org/obstore/latest/api/list/#obstore.list_with_delimiter): List objects within a specific directory.
 - [`sign`](https://developmentseed.org/obstore/latest/api/sign/): Create a signed URL.
+
+File-like object support is also provided:
+
+- [`open`](https://developmentseed.org/obstore/latest/api/file/#obstore.open): Open a remote object as a Python file-like object.
+- [`AsyncFsspecStore`](https://developmentseed.org/obstore/latest/api/fsspec/#obstore.fsspec.AsyncFsspecStore) adapter for use with [`fsspec`](https://github.com/fsspec/filesystem_spec).
 
 All methods have a comparable async method with the same name plus an `_async` suffix.
 

--- a/docs/api/file.md
+++ b/docs/api/file.md
@@ -1,4 +1,4 @@
-# File Object
+# File-like Object
 
 Native support for reading from object stores as a file-like object.
 

--- a/docs/api/file.md
+++ b/docs/api/file.md
@@ -1,0 +1,10 @@
+# File Object
+
+Native support for reading from object stores as a file-like object.
+
+Use `obstore.open` or `obstore.open_async` to open files. Writing files in this way is not yet supported.
+
+::: obstore.open
+::: obstore.open_async
+::: obstore.ReadableFile
+::: obstore.AsyncReadableFile

--- a/docs/api/fsspec.md
+++ b/docs/api/fsspec.md
@@ -1,0 +1,1 @@
+::: obstore.fsspec

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,7 +22,7 @@ extra:
 nav:
   - "index.md"
   - API Reference:
-      - store:
+      - obstore.store:
           - api/store/index.md
           - api/store/aws.md
           - api/store/gcs.md
@@ -41,6 +41,8 @@ nav:
       - api/sign.md
       - api/attributes.md
       - api/exceptions.md
+      - api/file.md
+      - obstore.fsspec: api/fsspec.md
 
 watch:
   - obstore/python
@@ -118,6 +120,7 @@ plugins:
 
           import:
             - https://docs.python.org/3/objects.inv
+            - https://filesystem-spec.readthedocs.io/en/latest/objects.inv
             - https://kylebarron.dev/arro3/latest/objects.inv
 
 # https://github.com/developmentseed/titiler/blob/50934c929cca2fa8d3c408d239015f8da429c6a8/docs/mkdocs.yml#L115-L140

--- a/obstore/python/obstore/_buffered.pyi
+++ b/obstore/python/obstore/_buffered.pyi
@@ -1,3 +1,4 @@
+import os
 from typing import List
 
 from ._buffer import Buffer
@@ -47,15 +48,15 @@ class ReadableFile:
     def readlines(self, hint: int = -1, /) -> List[Buffer]:
         """Read all remaining lines into a list of buffers"""
 
-    def seek(self, offset: int, whence: int, /) -> int:
+    def seek(self, offset: int, whence: int = os.SEEK_SET, /) -> int:
         """
         Change the stream position to the given byte _offset_, interpreted relative to
         the position indicated by _whence_, and return the new absolute position. Values
         for _whence_ are:
 
-        - [`os.SEEK_SET`] or 0: start of the stream (the default); `offset` should be zero or positive
-        - [`os.SEEK_CUR`] or 1: current stream position; `offset` may be negative
-        - [`os.SEEK_END`] or 2: end of the stream; `offset` is usually negative
+        - [`os.SEEK_SET`][] or 0: start of the stream (the default); `offset` should be zero or positive
+        - [`os.SEEK_CUR`][] or 1: current stream position; `offset` may be negative
+        - [`os.SEEK_END`][] or 2: end of the stream; `offset` is usually negative
         """
 
     def seekable(self) -> bool:
@@ -91,15 +92,15 @@ class AsyncReadableFile:
     async def readlines(self, hint: int = -1, /) -> List[Buffer]:
         """Read all remaining lines into a list of buffers"""
 
-    async def seek(self, offset: int, whence: int, /) -> int:
+    async def seek(self, offset: int, whence: int = os.SEEK_SET, /) -> int:
         """
         Change the stream position to the given byte _offset_, interpreted relative to
         the position indicated by _whence_, and return the new absolute position. Values
         for _whence_ are:
 
-        - [`os.SEEK_SET`] or 0: start of the stream (the default); `offset` should be zero or positive
-        - [`os.SEEK_CUR`] or 1: current stream position; `offset` may be negative
-        - [`os.SEEK_END`] or 2: end of the stream; `offset` is usually negative
+        - [`os.SEEK_SET`][] or 0: start of the stream (the default); `offset` should be zero or positive
+        - [`os.SEEK_CUR`][] or 1: current stream position; `offset` may be negative
+        - [`os.SEEK_END`][] or 2: end of the stream; `offset` is usually negative
         """
 
     def seekable(self) -> bool:

--- a/obstore/python/obstore/_obstore.pyi
+++ b/obstore/python/obstore/_obstore.pyi
@@ -1,5 +1,6 @@
 from ._attributes import Attribute as Attribute
 from ._attributes import Attributes as Attributes
+from ._buffered import AsyncReadableFile as AsyncReadableFile
 from ._buffered import ReadableFile as ReadableFile
 from ._buffered import open as open
 from ._buffered import open_async as open_async

--- a/obstore/python/obstore/fsspec.py
+++ b/obstore/python/obstore/fsspec.py
@@ -1,4 +1,6 @@
-"""Fsspec integration.
+"""[fsspec] integration.
+
+[fsspec]: https://github.com/fsspec/filesystem_spec
 
 The underlying `object_store` Rust crate [cautions](https://docs.rs/object_store/latest/object_store/#why-not-a-filesystem-interface) against relying too strongly on stateful filesystem representations of object stores:
 
@@ -29,7 +31,11 @@ import obstore as obs
 
 
 class AsyncFsspecStore(fsspec.asyn.AsyncFileSystem):
-    """An fsspec implementation based on a obstore Store"""
+    """An fsspec implementation based on a obstore Store.
+
+    You should be able to pass an instance of this class into any API that expects an
+    fsspec-style object.
+    """
 
     cachable = False
 
@@ -43,14 +49,28 @@ class AsyncFsspecStore(fsspec.asyn.AsyncFileSystem):
     ):
         """Construct a new AsyncFsspecStore
 
-        store: a configured instance of one of the store classes in objstore.store
-        asynchronous: id this instance meant to be be called using the async API? This
-            should only be set to true when running within a coroutine
-        loop: since both fsspec/python and tokio/rust may be using loops, this should
-            be kept `None` for now, and will not be used.
-        batch_size: some operations on many files will batch their requests; if you
-            are seeing timeouts, you may want to set this number smaller than the defaults,
-            which are determined in fsspec.asyn._get_batch_size
+        Args:
+            store: a configured instance of one of the store classes in `obstore.store`.
+            asynchronous: Set to `True` if this instance is meant to be be called using
+                the fsspec async API. This should only be set to true when running
+                within a coroutine.
+            loop: since both fsspec/python and tokio/rust may be using loops, this should
+                be kept `None` for now, and will not be used.
+            batch_size: some operations on many files will batch their requests; if you
+                are seeing timeouts, you may want to set this number smaller than the
+                defaults, which are determined in `fsspec.asyn._get_batch_size`.
+
+        Example:
+
+        ```py
+        from obstore.fsspec import AsyncFsspecStore
+        from obstore.store import HTTPStore
+
+        store = HTTPStore.from_url("https://example.com")
+        fsspec_store = AsyncFsspecStore(store)
+        resp = fsspec_store.cat("/")
+        assert resp.startswith(b"<!doctype html>")
+        ```
         """
 
         self.store = store

--- a/obstore/src/buffered.rs
+++ b/obstore/src/buffered.rs
@@ -246,39 +246,3 @@ async fn next_line(reader: Arc<Mutex<Lines<BufReader>>>, r#async: bool) -> PyRes
         Err(PyStopIteration::new_err("stream exhausted"))
     }
 }
-
-// #[cfg(test)]
-// mod test {
-
-//     use tokio::fs::File;
-//     use tokio::io::AsyncReadExt;
-
-//     #[tokio::test]
-//     async fn tmp() {
-//         let path = "/Users/kyle/github/developmentseed/object-store-rs/foo.txt";
-//         let mut f = File::open(path).await.unwrap();
-//         // let mut buffer = BytesMut::with_capacity(10);
-//         let mut buffer = vec![0; 10];
-
-//         dbg!(buffer.is_empty());
-//         dbg!(buffer.capacity());
-//         dbg!(buffer.len());
-
-//         // note that the return value is not needed to access the data
-//         // that was read as `buffer`'s internal cursor is updated.
-//         //
-//         // this might read more than 10 bytes if the capacity of `buffer`
-//         // is larger than 10.
-//         let amt = f.read(&mut buffer).await.unwrap();
-//         dbg!(buffer.len());
-//         dbg!(amt);
-//         // buffer.res
-
-//         println!("The bytes: {:?}", &buffer[..].to_ascii_lowercase());
-
-//         let amt = f.read(&mut buffer).await.unwrap();
-//         dbg!(buffer.len());
-//         dbg!(amt);
-//         println!("The bytes: {:?}", &buffer[..].to_ascii_lowercase());
-//     }
-// }


### PR DESCRIPTION
Add documentation for fsspec integration and native file-like object support.

Should still add to readme as well