### PR TITLE
Build 3.13 wheels on windows

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -54,6 +54,8 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist -i 3.9 -i 3.10 -i 3.11 -i 3.12 -i 3.13 -i pypy3.10 --manifest-path obstore/Cargo.toml
+          # This starting failing suddenly with
+          # sccache: error: Timed out waiting for server startup. Maybe the remote service is unreachable?
           # sccache: "true"
           manylinux: auto
       - name: Upload wheels

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -115,13 +115,13 @@ jobs:
       # Seems to be this question: https://stackoverflow.com/questions/78557803/python-with-rust-cannot-open-input-file-python3-lib
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.x
+          python-version: 3.13
           architecture: ${{ matrix.platform.target }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter --manifest-path obstore/Cargo.toml
+          args: --release --out dist -i 3.9 -i 3.10 -i 3.11 -i 3.12 -i 3.13 --manifest-path obstore/Cargo.toml
           sccache: "true"
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist -i 3.9 -i 3.10 -i 3.11 -i 3.12 -i 3.13 -i pypy3.10 --manifest-path obstore/Cargo.toml
-          sccache: "true"
+          # sccache: "true"
           manylinux: auto
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -136,7 +136,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-12
+          - runner: macos-13
             target: x86_64
           - runner: macos-14
             target: aarch64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1268,7 +1268,7 @@ dependencies = [
 
 [[package]]
 name = "obstore"
-version = "0.3.0-beta.8"
+version = "0.3.0-beta.9"
 dependencies = [
  "arrow",
  "bytes",

--- a/obstore/Cargo.toml
+++ b/obstore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "obstore"
-version = "0.3.0-beta.8"
+version = "0.3.0-beta.9"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "A Python interface to the Rust object_store crate, providing a uniform API for interacting with object storage services and local files."


### PR DESCRIPTION
### Change list

- Turn off sccache on linux because I got a spurious failure. Maybe this is something we could turn back on in the future?
- Add python 3.13 on Windows
- Update mac runner to macos-13
- Bump obstore beta version