### PR TITLE
Try to avoid refcount clone when importing PyObjectStore

### DIFF
--- a/obstore/src/get.rs
+++ b/obstore/src/get.rs
@@ -113,9 +113,6 @@ impl<'py> FromPyObject<'py> for PyGetRange {
         } else if let Ok(suffix_range) = ob.extract::<PySuffixRange>() {
             Ok(Self(suffix_range.into()))
         } else {
-            // dbg!(ob);
-            // let x = ob.extract::<PyOffsetRange>()?;
-            // dbg!(x.offset);
             Err(PyValueError::new_err("Unexpected input for byte range.\nExpected two-integer tuple or list, or dict with 'offset' or 'suffix' key." ))
         }
     }

--- a/pyo3-object_store/src/aws.rs
+++ b/pyo3-object_store/src/aws.rs
@@ -2,7 +2,8 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use object_store::aws::{AmazonS3, AmazonS3Builder, AmazonS3ConfigKey};
+use object_store::aws::{AmazonS3Builder, AmazonS3ConfigKey};
+use object_store::ObjectStore;
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedStr;
@@ -14,17 +15,17 @@ use crate::retry::PyRetryConfig;
 
 /// A Python-facing wrapper around an [`AmazonS3`].
 #[pyclass(name = "S3Store", frozen)]
-pub struct PyS3Store(Arc<AmazonS3>);
+pub struct PyS3Store(Arc<dyn ObjectStore>);
 
-impl AsRef<Arc<AmazonS3>> for PyS3Store {
-    fn as_ref(&self) -> &Arc<AmazonS3> {
+impl AsRef<Arc<dyn ObjectStore>> for PyS3Store {
+    fn as_ref(&self) -> &Arc<dyn ObjectStore> {
         &self.0
     }
 }
 
 impl PyS3Store {
     /// Consume self and return the underlying [`AmazonS3`].
-    pub fn into_inner(self) -> Arc<AmazonS3> {
+    pub fn into_inner(self) -> Arc<dyn ObjectStore> {
         self.0
     }
 }

--- a/pyo3-object_store/src/azure.rs
+++ b/pyo3-object_store/src/azure.rs
@@ -2,7 +2,8 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use object_store::azure::{AzureConfigKey, MicrosoftAzure, MicrosoftAzureBuilder};
+use object_store::azure::{AzureConfigKey, MicrosoftAzureBuilder};
+use object_store::ObjectStore;
 use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedStr;
 use pyo3::types::PyType;
@@ -13,17 +14,17 @@ use crate::retry::PyRetryConfig;
 
 /// A Python-facing wrapper around a [`MicrosoftAzure`].
 #[pyclass(name = "AzureStore", frozen)]
-pub struct PyAzureStore(Arc<MicrosoftAzure>);
+pub struct PyAzureStore(Arc<dyn ObjectStore>);
 
-impl AsRef<Arc<MicrosoftAzure>> for PyAzureStore {
-    fn as_ref(&self) -> &Arc<MicrosoftAzure> {
+impl AsRef<Arc<dyn ObjectStore>> for PyAzureStore {
+    fn as_ref(&self) -> &Arc<dyn ObjectStore> {
         &self.0
     }
 }
 
 impl PyAzureStore {
     /// Consume self and return the underlying [`MicrosoftAzure`].
-    pub fn into_inner(self) -> Arc<MicrosoftAzure> {
+    pub fn into_inner(self) -> Arc<dyn ObjectStore> {
         self.0
     }
 }

--- a/pyo3-object_store/src/gcp.rs
+++ b/pyo3-object_store/src/gcp.rs
@@ -2,7 +2,8 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use object_store::gcp::{GoogleCloudStorage, GoogleCloudStorageBuilder, GoogleConfigKey};
+use object_store::gcp::{GoogleCloudStorageBuilder, GoogleConfigKey};
+use object_store::ObjectStore;
 use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedStr;
 use pyo3::types::PyType;
@@ -13,17 +14,17 @@ use crate::retry::PyRetryConfig;
 
 /// A Python-facing wrapper around a [`GoogleCloudStorage`].
 #[pyclass(name = "GCSStore", frozen)]
-pub struct PyGCSStore(Arc<GoogleCloudStorage>);
+pub struct PyGCSStore(Arc<dyn ObjectStore>);
 
-impl AsRef<Arc<GoogleCloudStorage>> for PyGCSStore {
-    fn as_ref(&self) -> &Arc<GoogleCloudStorage> {
+impl AsRef<Arc<dyn ObjectStore>> for PyGCSStore {
+    fn as_ref(&self) -> &Arc<dyn ObjectStore> {
         &self.0
     }
 }
 
 impl PyGCSStore {
     /// Consume self and return the underlying [`GoogleCloudStorage`].
-    pub fn into_inner(self) -> Arc<GoogleCloudStorage> {
+    pub fn into_inner(self) -> Arc<dyn ObjectStore> {
         self.0
     }
 }

--- a/pyo3-object_store/src/http.rs
+++ b/pyo3-object_store/src/http.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
-use object_store::http::{HttpBuilder, HttpStore};
+use object_store::http::HttpBuilder;
+use object_store::ObjectStore;
 use pyo3::prelude::*;
 use pyo3::types::PyType;
 
@@ -10,17 +11,17 @@ use crate::PyClientOptions;
 
 /// A Python-facing wrapper around a [`HttpStore`].
 #[pyclass(name = "HTTPStore", frozen)]
-pub struct PyHttpStore(Arc<HttpStore>);
+pub struct PyHttpStore(Arc<dyn ObjectStore>);
 
-impl AsRef<Arc<HttpStore>> for PyHttpStore {
-    fn as_ref(&self) -> &Arc<HttpStore> {
+impl AsRef<Arc<dyn ObjectStore>> for PyHttpStore {
+    fn as_ref(&self) -> &Arc<dyn ObjectStore> {
         &self.0
     }
 }
 
 impl PyHttpStore {
     /// Consume self and return the underlying [`HttpStore`].
-    pub fn into_inner(self) -> Arc<HttpStore> {
+    pub fn into_inner(self) -> Arc<dyn ObjectStore> {
         self.0
     }
 

--- a/pyo3-object_store/src/local.rs
+++ b/pyo3-object_store/src/local.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use object_store::local::LocalFileSystem;
-use object_store::ObjectStoreScheme;
+use object_store::{ObjectStore, ObjectStoreScheme};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyType;
@@ -11,17 +11,17 @@ use crate::error::PyObjectStoreResult;
 
 /// A Python-facing wrapper around a [`LocalFileSystem`].
 #[pyclass(name = "LocalStore", frozen)]
-pub struct PyLocalStore(Arc<LocalFileSystem>);
+pub struct PyLocalStore(Arc<dyn ObjectStore>);
 
-impl AsRef<Arc<LocalFileSystem>> for PyLocalStore {
-    fn as_ref(&self) -> &Arc<LocalFileSystem> {
+impl AsRef<Arc<dyn ObjectStore>> for PyLocalStore {
+    fn as_ref(&self) -> &Arc<dyn ObjectStore> {
         &self.0
     }
 }
 
 impl PyLocalStore {
     /// Consume self and return the underlying [`LocalFileSystem`].
-    pub fn into_inner(self) -> Arc<LocalFileSystem> {
+    pub fn into_inner(self) -> Arc<dyn ObjectStore> {
         self.0
     }
 }

--- a/pyo3-object_store/src/memory.rs
+++ b/pyo3-object_store/src/memory.rs
@@ -1,23 +1,24 @@
 use std::sync::Arc;
 
 use object_store::memory::InMemory;
+use object_store::ObjectStore;
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyString;
 
 /// A Python-facing wrapper around an [`InMemory`].
 #[pyclass(name = "MemoryStore", frozen)]
-pub struct PyMemoryStore(Arc<InMemory>);
+pub struct PyMemoryStore(Arc<dyn ObjectStore>);
 
-impl AsRef<Arc<InMemory>> for PyMemoryStore {
-    fn as_ref(&self) -> &Arc<InMemory> {
+impl AsRef<Arc<dyn ObjectStore>> for PyMemoryStore {
+    fn as_ref(&self) -> &Arc<dyn ObjectStore> {
         &self.0
     }
 }
 
 impl<'py> PyMemoryStore {
     /// Consume self and return the underlying [`InMemory`].
-    pub fn into_inner(self) -> Arc<InMemory> {
+    pub fn into_inner(self) -> Arc<dyn ObjectStore> {
         self.0
     }
 

--- a/pyo3-object_store/src/store.rs
+++ b/pyo3-object_store/src/store.rs
@@ -13,22 +13,22 @@ use crate::{PyAzureStore, PyGCSStore, PyLocalStore, PyMemoryStore, PyS3Store};
 /// ObjectStore.
 // (In the future we'll have a separate AnyObjectStore that allows either an fsspec-based
 // implementation or a rust-based implementation.)
-pub struct PyObjectStore(Arc<dyn ObjectStore>);
+pub struct PyObjectStore<'py>(&'py Arc<dyn ObjectStore>);
 
-impl<'py> FromPyObject<'py> for PyObjectStore {
+impl<'py> FromPyObject<'py> for PyObjectStore<'py> {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         if let Ok(store) = ob.downcast::<PyS3Store>() {
-            Ok(Self(store.get().as_ref().clone()))
+            Ok(Self(store.get().as_ref()))
         } else if let Ok(store) = ob.downcast::<PyAzureStore>() {
-            Ok(Self(store.get().as_ref().clone()))
+            Ok(Self(store.get().as_ref()))
         } else if let Ok(store) = ob.downcast::<PyGCSStore>() {
-            Ok(Self(store.get().as_ref().clone()))
+            Ok(Self(store.get().as_ref()))
         } else if let Ok(store) = ob.downcast::<PyHttpStore>() {
-            Ok(Self(store.get().as_ref().clone()))
+            Ok(Self(store.get().as_ref()))
         } else if let Ok(store) = ob.downcast::<PyLocalStore>() {
-            Ok(Self(store.get().as_ref().clone()))
+            Ok(Self(store.get().as_ref()))
         } else if let Ok(store) = ob.downcast::<PyMemoryStore>() {
-            Ok(Self(store.get().as_ref().clone()))
+            Ok(Self(store.get().as_ref()))
         } else {
             let py = ob.py();
             // Check for object-store instance from other library
@@ -58,15 +58,15 @@ impl<'py> FromPyObject<'py> for PyObjectStore {
     }
 }
 
-impl AsRef<Arc<dyn ObjectStore>> for PyObjectStore {
+impl<'py> AsRef<Arc<dyn ObjectStore>> for PyObjectStore<'py> {
     fn as_ref(&self) -> &Arc<dyn ObjectStore> {
         &self.0
     }
 }
 
-impl PyObjectStore {
+impl<'py> PyObjectStore<'py> {
     /// Consume self and return the underlying [`ObjectStore`].
-    pub fn into_inner(self) -> Arc<dyn ObjectStore> {
+    pub fn into_inner(self) -> &'py Arc<dyn ObjectStore> {
         self.0
     }
 }


### PR DESCRIPTION
I don't think this is possible:

```
error: lifetime may not live long enough
  --> pyo3-object_store/src/store.rs:20:28
   |
18 | impl<'py> FromPyObject<'py> for PyObjectStore<'py> {
   |      --- lifetime `'py` defined here
19 |     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
   |                          - let's call the lifetime of this reference `'1`
20 |         if let Ok(store) = ob.downcast::<PyS3Store>() {
   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'1` must outlive `'py`
```