### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ jobs:
         with:
           submodules: "recursive"
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # obstore
 
+hi
+
 [![PyPI][pypi_badge]][pypi_link]
 [![Conda Version][conda_version_badge]][conda_version]
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # obstore
 
-hi
-
 [![PyPI][pypi_badge]][pypi_link]
 [![Conda Version][conda_version_badge]][conda_version]
 


### PR DESCRIPTION
I'm not sure exactly what changed but now Python is needed for the lint-test CI run.