### PR TITLE
Implement many Python methods of `bytes` on `Bytes`

### DIFF
--- a/pyo3-bytes/README.md
+++ b/pyo3-bytes/README.md
@@ -52,28 +52,9 @@ For more reading:
 
 ## Python type hints
 
-PyBytes has a small type surface, making it easy to copy the relevant type hint
-into your library.
+On the Python side, the exported `Bytes` class implements many of the same
+methods (with the same signature) as the Python `bytes` object.
 
-```py
-import sys
-
-if sys.version_info >= (3, 12):
-    from collections.abc import Buffer as _Buffer
-else:
-    from typing_extensions import Buffer as _Buffer
-
-class Bytes(_Buffer):
-    """
-    A buffer implementing the Python buffer protocol, allowing zero-copy access
-    to underlying Rust memory.
-
-    You can pass this to `memoryview` for a zero-copy view into the underlying
-    data.
-    """
-
-    def to_bytes(self) -> bytes:
-        """Copy this buffer's contents into a Python `bytes` object."""
-    def __repr__(self) -> str: ...
-    def __len__(self) -> int: ...
-```
+The Python type hints are available in the Github repo in the file `bytes.pyi`.
+I don't know the best way to distribute this to downstream projects. If you have
+an idea, create an issue to discuss.

--- a/pyo3-bytes/bytes.pyi
+++ b/pyo3-bytes/bytes.pyi
@@ -1,0 +1,91 @@
+import sys
+
+if sys.version_info >= (3, 12):
+    from collections.abc import Buffer
+else:
+    from typing_extensions import Buffer
+
+class Bytes(Buffer):
+    """
+    A buffer implementing the Python buffer protocol, allowing zero-copy access
+    to underlying Rust memory.
+
+    You can pass this to `memoryview` for a zero-copy view into the underlying
+    data.
+    """
+
+    def __add__(self, other: Buffer) -> Bytes: ...
+    def __contains__(self, other: Buffer) -> bool: ...
+    def __eq__(self, other: object) -> bool: ...
+    def __getitem__(self, other: int) -> int: ...
+    def __mul__(self, other: Buffer) -> int: ...
+    def __len__(self) -> int: ...
+    def __repr__(self) -> str: ...
+    def removeprefix(self, prefix: Buffer, /) -> Bytes:
+        """
+        If the binary data starts with the prefix string, return `bytes[len(prefix):]`.
+        Otherwise, return the original binary data.
+        """
+    def removesuffix(self, suffix: Buffer, /) -> Bytes:
+        """
+        If the binary data ends with the suffix string and that suffix is not empty,
+        return `bytes[:-len(suffix)]`. Otherwise, return the original binary data.
+        """
+    def isalnum(self) -> bool:
+        """
+        Return True if all bytes in the sequence are alphabetical ASCII characters or
+        ASCII decimal digits and the sequence is not empty, False otherwise. Alphabetic
+        ASCII characters are those byte values in the sequence
+        b'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'. ASCII decimal digits
+        are those byte values in the sequence b'0123456789'.
+        """
+    def isalpha(self) -> bool:
+        """
+        Return True if all bytes in the sequence are alphabetic ASCII characters and the
+        sequence is not empty, False otherwise. Alphabetic ASCII characters are those
+        byte values in the sequence
+        b'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'.
+        """
+    def isascii(self) -> bool:
+        """
+        Return True if the sequence is empty or all bytes in the sequence are ASCII,
+        False otherwise. ASCII bytes are in the range 0-0x7F.
+        """
+    def isdigit(self) -> bool:
+        """
+        Return True if all bytes in the sequence are ASCII decimal digits and the
+        sequence is not empty, False otherwise. ASCII decimal digits are those byte
+        values in the sequence b'0123456789'.
+        """
+    def islower(self) -> bool:
+        """
+        Return True if there is at least one lowercase ASCII character in the sequence
+        and no uppercase ASCII characters, False otherwise.
+        """
+    def isspace(self) -> bool:
+        """
+        Return True if all bytes in the sequence are ASCII whitespace and the sequence
+        is not empty, False otherwise. ASCII whitespace characters are those byte values
+        in the sequence b' \t\n\r\x0b\f' (space, tab, newline, carriage return, vertical
+        tab, form feed).
+        """
+    def isupper(self) -> bool:
+        """
+        Return True if there is at least one uppercase alphabetic ASCII character in the
+        sequence and no lowercase ASCII characters, False otherwise.
+        """
+
+    def lower(self) -> Bytes:
+        """
+        Return a copy of the sequence with all the uppercase ASCII characters converted
+        to their corresponding lowercase counterpart.
+        """
+
+    def upper(self) -> Bytes:
+        """
+        Return a copy of the sequence with all the lowercase ASCII characters converted
+        to their corresponding uppercase counterpart.
+        """
+
+    def to_bytes(self) -> bytes:
+        """Copy this buffer's contents into a Python `bytes` object."""

--- a/pyo3-bytes/src/bytes.rs
+++ b/pyo3-bytes/src/bytes.rs
@@ -3,12 +3,12 @@
 use std::os::raw::c_int;
 use std::ptr::NonNull;
 
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 
 use pyo3::buffer::PyBuffer;
-use pyo3::exceptions::PyValueError;
-use pyo3::ffi;
+use pyo3::exceptions::{PyIndexError, PyValueError};
 use pyo3::prelude::*;
+use pyo3::{ffi, IntoPyObjectExt};
 
 /// A wrapper around a [`bytes::Bytes`][].
 ///
@@ -31,7 +31,7 @@ use pyo3::prelude::*;
 /// data view without copies. In Python, this `PyBytes` object can be passed to Python `bytes` or
 /// `memoryview` constructors, `numpy.frombuffer`, or any other function that supports buffer
 /// protocol input.
-#[pyclass(name = "Bytes", subclass, frozen)]
+#[pyclass(name = "Bytes", subclass, frozen, sequence, weakref)]
 #[derive(Debug, Hash, PartialEq, PartialOrd, Eq, Ord)]
 pub struct PyBytes(Bytes);
 
@@ -57,6 +57,11 @@ impl PyBytes {
     pub fn into_inner(self) -> Bytes {
         self.0
     }
+
+    /// Access the underlying buffer as a byte slice
+    pub fn as_slice(&self) -> &[u8] {
+        self.as_ref()
+    }
 }
 
 impl From<PyBytes> for Bytes {
@@ -65,9 +70,21 @@ impl From<PyBytes> for Bytes {
     }
 }
 
+impl From<Vec<u8>> for PyBytes {
+    fn from(value: Vec<u8>) -> Self {
+        PyBytes(value.into())
+    }
+}
+
 impl From<Bytes> for PyBytes {
     fn from(value: Bytes) -> Self {
         PyBytes(value)
+    }
+}
+
+impl From<BytesMut> for PyBytes {
+    fn from(value: BytesMut) -> Self {
+        PyBytes(value.into())
     }
 }
 
@@ -80,18 +97,54 @@ impl PyBytes {
         buf
     }
 
-    /// Copy this buffer's contents to a Python `bytes` object
-    fn to_bytes<'py>(&'py self, py: Python<'py>) -> Bound<'py, pyo3::types::PyBytes> {
-        pyo3::types::PyBytes::new(py, &self.0)
-    }
-
     /// The number of bytes in this Bytes
     fn __len__(&self) -> usize {
         self.0.len()
     }
 
     fn __repr__(&self) -> String {
-        format!("Bytes(len={})", self.0.len())
+        format!("Bytes({})", self.0.len())
+    }
+
+    fn __add__(&self, other: PyBytes) -> PyBytes {
+        let total_length = self.0.len() + other.0.len();
+        let mut new_buffer = BytesMut::with_capacity(total_length);
+        new_buffer.extend_from_slice(&self.0);
+        new_buffer.extend_from_slice(&other.0);
+        new_buffer.into()
+    }
+
+    fn __contains__(&self, item: PyBytes) -> bool {
+        self.0
+            .windows(item.0.len())
+            .any(|window| window == item.as_slice())
+    }
+
+    fn __eq__(&self, other: PyBytes) -> bool {
+        self.0.as_ref() == other.0.as_ref()
+    }
+
+    fn __getitem__(&self, py: Python, key: Bound<PyAny>) -> PyResult<PyObject> {
+        if let Ok(mut index) = key.extract::<isize>() {
+            if index < 0 {
+                index += self.0.len() as isize;
+            }
+
+            self.0
+                .get(index as usize)
+                .ok_or(PyIndexError::new_err("Index out of range"))?
+                .into_py_any(py)
+        } else {
+            Err(PyValueError::new_err(
+                "Currently, only integer keys are allowed in __getitem__.",
+            ))
+        }
+    }
+
+    fn __mul__(&self, value: usize) -> PyBytes {
+        let mut out_buf = BytesMut::with_capacity(self.0.len() * value);
+        (0..value).for_each(|_| out_buf.extend_from_slice(self.0.as_ref()));
+        out_buf.into()
     }
 
     /// This is taken from opendal:
@@ -122,6 +175,154 @@ impl PyBytes {
     // > the allocation owned by the object.
     // https://discord.com/channels/1209263839632424990/1324816949464666194/1328299411427557397
     unsafe fn __releasebuffer__(&self, _view: *mut ffi::Py_buffer) {}
+
+    /// If the binary data starts with the prefix string, return bytes[len(prefix):]. Otherwise,
+    /// return a copy of the original binary data:
+    #[pyo3(signature = (prefix, /))]
+    fn removeprefix(&self, prefix: PyBytes) -> PyBytes {
+        if self.0.starts_with(prefix.as_ref()) {
+            self.0.slice(prefix.0.len()..).into()
+        } else {
+            self.0.clone().into()
+        }
+    }
+
+    /// If the binary data ends with the suffix string and that suffix is not empty, return
+    /// `bytes[:-len(suffix)]`. Otherwise, return the original binary data.
+    #[pyo3(signature = (suffix, /))]
+    fn removesuffix(&self, suffix: PyBytes) -> PyBytes {
+        if self.0.ends_with(suffix.as_ref()) {
+            self.0.slice(0..self.0.len() - suffix.0.len()).into()
+        } else {
+            self.0.clone().into()
+        }
+    }
+
+    /// Return True if all bytes in the sequence are alphabetical ASCII characters or ASCII decimal
+    /// digits and the sequence is not empty, False otherwise. Alphabetic ASCII characters are
+    /// those byte values in the sequence b'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'.
+    /// ASCII decimal digits are those byte values in the sequence b'0123456789'.
+    fn isalnum(&self) -> bool {
+        if self.0.is_empty() {
+            return false;
+        }
+
+        for c in self.0.as_ref() {
+            if !c.is_ascii_alphanumeric() {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Return True if all bytes in the sequence are alphabetic ASCII characters and the sequence
+    /// is not empty, False otherwise. Alphabetic ASCII characters are those byte values in the
+    /// sequence b'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'.
+    fn isalpha(&self) -> bool {
+        if self.0.is_empty() {
+            return false;
+        }
+
+        for c in self.0.as_ref() {
+            if !c.is_ascii_alphabetic() {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Return True if the sequence is empty or all bytes in the sequence are ASCII, False
+    /// otherwise. ASCII bytes are in the range 0-0x7F.
+    fn isascii(&self) -> bool {
+        for c in self.0.as_ref() {
+            if !c.is_ascii() {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Return True if all bytes in the sequence are ASCII decimal digits and the sequence is not
+    /// empty, False otherwise. ASCII decimal digits are those byte values in the sequence
+    /// b'0123456789'.
+    fn isdigit(&self) -> bool {
+        if self.0.is_empty() {
+            return false;
+        }
+
+        for c in self.0.as_ref() {
+            if !c.is_ascii_digit() {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Return True if there is at least one lowercase ASCII character in the sequence and no
+    /// uppercase ASCII characters, False otherwise.
+    fn islower(&self) -> bool {
+        let mut has_lower = false;
+        for c in self.0.as_ref() {
+            if c.is_ascii_uppercase() {
+                return false;
+            }
+            if !has_lower && c.is_ascii_lowercase() {
+                has_lower = true;
+            }
+        }
+
+        has_lower
+    }
+
+    /// Return True if all bytes in the sequence are ASCII whitespace and the sequence is not
+    /// empty, False otherwise. ASCII whitespace characters are those byte values in the sequence
+    /// b' \t\n\r\x0b\f' (space, tab, newline, carriage return, vertical tab, form feed).
+    fn isspace(&self) -> bool {
+        if self.0.is_empty() {
+            return false;
+        }
+
+        for c in self.0.as_ref() {
+            // Also check for vertical tab
+            if !(c.is_ascii_whitespace() || *c == b'\x0b') {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Return True if there is at least one uppercase alphabetic ASCII character in the sequence
+    /// and no lowercase ASCII characters, False otherwise.
+    fn isupper(&self) -> bool {
+        let mut has_upper = false;
+        for c in self.0.as_ref() {
+            if c.is_ascii_lowercase() {
+                return false;
+            }
+            if !has_upper && c.is_ascii_uppercase() {
+                has_upper = true;
+            }
+        }
+
+        has_upper
+    }
+
+    /// Return a copy of the sequence with all the uppercase ASCII characters converted to their
+    /// corresponding lowercase counterpart.
+    fn lower(&self) -> PyBytes {
+        self.0.to_ascii_lowercase().into()
+    }
+
+    /// Return a copy of the sequence with all the lowercase ASCII characters converted to their
+    /// corresponding uppercase counterpart.
+    fn upper(&self) -> PyBytes {
+        self.0.to_ascii_uppercase().into()
+    }
+
+    /// Copy this buffer's contents to a Python `bytes` object
+    fn to_bytes<'py>(&'py self, py: Python<'py>) -> Bound<'py, pyo3::types::PyBytes> {
+        pyo3::types::PyBytes::new(py, &self.0)
+    }
 }
 
 impl<'py> FromPyObject<'py> for PyBytes {


### PR DESCRIPTION
See python docs on [datamodel](https://docs.python.org/3/reference/datamodel.html#object.__iter__), [common sequence operations](https://docs.python.org/3/library/stdtypes.html#typesseq-common), [bytes and bytearray operations](https://docs.python.org/3/library/stdtypes.html#bytes-and-bytearray-operations).

Not all methods are implemented. They can be further implemented in the future when people ask for it.