### PR TITLE
Implement read_all for async iterable

### DIFF
--- a/obstore/python/obstore/_put.pyi
+++ b/obstore/python/obstore/_put.pyi
@@ -101,7 +101,7 @@ def put(
         mode: Configure the `PutMode` for this operation. If this provided and is not `"overwrite"`, a non-multipart upload will be performed. Defaults to `"overwrite"`.
         attributes: Provide a set of `Attributes`. Defaults to `None`.
         tags: Provide tags for this object. Defaults to `None`.
-        use_multipart: Whether to use a multipart upload under the hood. Defaults using a multipart upload if the length of the file is greater than `chunk_size`.
+        use_multipart: Whether to use a multipart upload under the hood. Defaults using a multipart upload if the length of the file is greater than `chunk_size`. When `use_multipart` is `False`, the entire input will be materialized in memory as part of the upload.
         chunk_size: The size of chunks to use within each part of the multipart upload. Defaults to 5 MB.
         max_concurrency: The maximum number of chunks to upload concurrently. Defaults to 12.
     """

--- a/obstore/src/put.rs
+++ b/obstore/src/put.rs
@@ -239,7 +239,7 @@ impl PutInput {
         }
     }
 
-    async fn read_all(&mut self) -> PyObjectStoreResult<Bytes> {
+    async fn read_all(&mut self) -> PyObjectStoreResult<PutPayload> {
         match self {
             Self::Pull(pull_source) => {
                 let mut buf = Vec::new();
@@ -432,8 +432,7 @@ async fn put_inner(
         opts.mode = mode.0;
     }
 
-    let buffer = reader.read_all().await?;
-    let payload = PutPayload::from_bytes(buffer);
+    let payload = reader.read_all().await?;
     Ok(PyPutResult(store.put_opts(path, payload, opts).await?))
 }
 

--- a/tests/test_put.py
+++ b/tests/test_put.py
@@ -14,6 +14,29 @@ def test_put_non_multipart():
     assert obs.get(store, "file1.txt").bytes() == b"foo"
 
 
+def test_put_non_multipart_sync_iterable():
+    store = MemoryStore()
+
+    b = b"the quick brown fox jumps over the lazy dog,"
+    iterator = itertools.repeat(b, 5)
+    obs.put(store, "file1.txt", iterator, use_multipart=False)
+    assert obs.get(store, "file1.txt").bytes() == (b * 5)
+
+
+@pytest.mark.asyncio
+async def test_put_non_multipart_async_iterable():
+    store = MemoryStore()
+
+    b = b"the quick brown fox jumps over the lazy dog,"
+
+    async def it():
+        for i in range(5):
+            yield b"the quick brown fox jumps over the lazy dog,"
+
+    await obs.put_async(store, "file1.txt", it(), use_multipart=False)
+    assert obs.get(store, "file1.txt").bytes() == (b * 5)
+
+
 def test_put_multipart_one_chunk():
     store = MemoryStore()
 


### PR DESCRIPTION
### Change list

- Implement `read_all` for `AsyncPushSource`
- Change `read_all` to not copy buffer protocol input.