### PR TITLE
Allow config options as kwargs to the builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,10 @@ Additionally, some middlewares exist:
 #### Example
 
 ```py
-import boto3
 from obstore.store import S3Store
 
 session = boto3.Session()
-store = S3Store.from_session(session, "bucket-name", config={"AWS_REGION": "us-east-1"})
+store = S3Store("bucket-name", region="us-east-1")
 ```
 
 #### Configuration

--- a/docs/api/store/aws.md
+++ b/docs/api/store/aws.md
@@ -1,4 +1,6 @@
 # AWS S3
 
 ::: obstore.store.S3Store
-::: obstore.store.S3ConfigKey
+::: obstore.store.S3Config
+    options:
+        show_if_no_docstring: true

--- a/docs/api/store/azure.md
+++ b/docs/api/store/azure.md
@@ -1,4 +1,6 @@
 # Microsoft Azure
 
 ::: obstore.store.AzureStore
-::: obstore.store.AzureConfigKey
+::: obstore.store.AzureConfig
+    options:
+        show_if_no_docstring: true

--- a/docs/api/store/config.md
+++ b/docs/api/store/config.md
@@ -1,5 +1,5 @@
 # Configuration
 
-::: obstore.store.ClientConfigKey
+::: obstore.store.ClientConfig
 ::: obstore.store.BackoffConfig
 ::: obstore.store.RetryConfig

--- a/docs/api/store/gcs.md
+++ b/docs/api/store/gcs.md
@@ -1,4 +1,6 @@
 # Google Cloud Storage
 
 ::: obstore.store.GCSStore
-::: obstore.store.GCSConfigKey
+::: obstore.store.GCSConfig
+    options:
+        show_if_no_docstring: true

--- a/obstore/python/obstore/store/__init__.pyi
+++ b/obstore/python/obstore/store/__init__.pyi
@@ -1,12 +1,12 @@
 # TODO: move to reusable types package
 from pathlib import Path
 
-from ._aws import S3ConfigKey as S3ConfigKey
+from ._aws import S3Config as S3Config
 from ._aws import S3Store as S3Store
-from ._azure import AzureConfigKey as AzureConfigKey
+from ._azure import AzureConfig as AzureConfig
 from ._azure import AzureStore as AzureStore
 from ._client import ClientConfigKey as ClientConfigKey
-from ._gcs import GCSConfigKey as GCSConfigKey
+from ._gcs import GCSConfig as GCSConfig
 from ._gcs import GCSStore as GCSStore
 from ._http import HTTPStore as HTTPStore
 from ._prefix import PrefixStore as PrefixStore

--- a/obstore/python/obstore/store/__init__.pyi
+++ b/obstore/python/obstore/store/__init__.pyi
@@ -5,7 +5,7 @@ from ._aws import S3Config as S3Config
 from ._aws import S3Store as S3Store
 from ._azure import AzureConfig as AzureConfig
 from ._azure import AzureStore as AzureStore
-from ._client import ClientConfigKey as ClientConfigKey
+from ._client import ClientConfig as ClientConfig
 from ._gcs import GCSConfig as GCSConfig
 from ._gcs import GCSStore as GCSStore
 from ._http import HTTPStore as HTTPStore

--- a/obstore/python/obstore/store/_aws.pyi
+++ b/obstore/python/obstore/store/_aws.pyi
@@ -11,119 +11,172 @@ from ._retry import RetryConfig
 # Note: we removed `bucket` because it overlaps with an existing named arg in the
 # constructors
 class S3Config(TypedDict, total=False):
+    """Configuration parameters for S3Store.
+
+    There are duplicates of many parameters, and parameters can be either upper or lower
+    case. Not all parameters are required.
+    """
+
     access_key_id: str
+    """AWS Access Key"""
     aws_access_key_id: str
+    """AWS Access Key"""
     aws_allow_http: str
     aws_bucket_name: str
+    """Bucket name"""
     aws_bucket: str
+    """Bucket name"""
     aws_checksum_algorithm: str
     aws_conditional_put: str
     aws_container_credentials_relative_uri: str
     aws_copy_if_not_exists: str
     aws_default_region: str
+    """Default region"""
     aws_disable_tagging: str
+    """Disable tagging objects. This can be desirable if not supported by the backing store."""
     aws_endpoint_url: str
+    """Sets custom endpoint for communicating with AWS S3."""
     aws_endpoint: str
+    """Sets custom endpoint for communicating with AWS S3."""
     aws_imdsv1_fallback: str
+    """Fall back to ImdsV1"""
     aws_metadata_endpoint: str
+    """Set the instance metadata endpoint"""
     aws_region: str
+    """Region"""
     aws_request_payer: str
+    """If `True`, enable operations on requester-pays buckets."""
     aws_s3_express: str
+    """Enable Support for S3 Express One Zone"""
     aws_secret_access_key: str
+    """Secret Access Key"""
     aws_server_side_encryption: str
     aws_session_token: str
+    """Token to use for requests (passed to underlying provider)"""
     aws_skip_signature: str
     aws_sse_bucket_key_enabled: str
     aws_sse_kms_key_id: str
     aws_token: str
+    """Token to use for requests (passed to underlying provider)"""
     aws_unsigned_payload: str
+    """Avoid computing payload checksum when calculating signature."""
     aws_virtual_hosted_style_request: str
+    """If virtual hosted style request has to be used."""
     bucket_name: str
+    """Bucket name"""
     checksum_algorithm: str
     conditional_put: str
     copy_if_not_exists: str
     default_region: str
+    """Default region"""
     disable_tagging: str
+    """Disable tagging objects. This can be desirable if not supported by the backing store."""
     endpoint_url: str
+    """Sets custom endpoint for communicating with AWS S3."""
     endpoint: str
+    """Sets custom endpoint for communicating with AWS S3."""
     imdsv1_fallback: str
+    """Fall back to ImdsV1"""
     metadata_endpoint: str
+    """Set the instance metadata endpoint"""
     region: str
+    """Region"""
     request_payer: str
+    """If `True`, enable operations on requester-pays buckets."""
     s3_express: str
+    """Enable Support for S3 Express One Zone"""
     secret_access_key: str
+    """Secret Access Key"""
     session_token: str
+    """Token to use for requests (passed to underlying provider)"""
     skip_signature: str
     token: str
+    """Token to use for requests (passed to underlying provider)"""
     unsigned_payload: str
+    """Avoid computing payload checksum when calculating signature."""
     virtual_hosted_style_request: str
+    """If virtual hosted style request has to be used."""
     ACCESS_KEY_ID: str
+    """AWS Access Key"""
     AWS_ACCESS_KEY_ID: str
+    """AWS Access Key"""
     AWS_ALLOW_HTTP: str
     AWS_BUCKET_NAME: str
+    """Bucket name"""
     AWS_BUCKET: str
+    """Bucket name"""
     AWS_CHECKSUM_ALGORITHM: str
     AWS_CONDITIONAL_PUT: str
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: str
     AWS_COPY_IF_NOT_EXISTS: str
     AWS_DEFAULT_REGION: str
+    """Default region"""
     AWS_DISABLE_TAGGING: str
+    """Disable tagging objects. This can be desirable if not supported by the backing store."""
     AWS_ENDPOINT_URL: str
+    """Sets custom endpoint for communicating with AWS S3."""
     AWS_ENDPOINT: str
+    """Sets custom endpoint for communicating with AWS S3."""
     AWS_IMDSV1_FALLBACK: str
+    """Fall back to ImdsV1"""
     AWS_METADATA_ENDPOINT: str
+    """Set the instance metadata endpoint"""
     AWS_REGION: str
+    """Region"""
     AWS_REQUEST_PAYER: str
+    """If `True`, enable operations on requester-pays buckets."""
     AWS_S3_EXPRESS: str
+    """Enable Support for S3 Express One Zone"""
     AWS_SECRET_ACCESS_KEY: str
+    """Secret Access Key"""
     AWS_SERVER_SIDE_ENCRYPTION: str
     AWS_SESSION_TOKEN: str
+    """Token to use for requests (passed to underlying provider)"""
     AWS_SKIP_SIGNATURE: str
     AWS_SSE_BUCKET_KEY_ENABLED: str
     AWS_SSE_KMS_KEY_ID: str
     AWS_TOKEN: str
+    """Token to use for requests (passed to underlying provider)"""
     AWS_UNSIGNED_PAYLOAD: str
+    """Avoid computing payload checksum when calculating signature."""
     AWS_VIRTUAL_HOSTED_STYLE_REQUEST: str
+    """If virtual hosted style request has to be used."""
     BUCKET_NAME: str
+    """Bucket name"""
     BUCKET: str
+    """Bucket name"""
     CHECKSUM_ALGORITHM: str
     CONDITIONAL_PUT: str
     COPY_IF_NOT_EXISTS: str
     DEFAULT_REGION: str
+    """Default region"""
     DISABLE_TAGGING: str
+    """Disable tagging objects. This can be desirable if not supported by the backing store."""
     ENDPOINT_URL: str
+    """Sets custom endpoint for communicating with AWS S3."""
     ENDPOINT: str
+    """Sets custom endpoint for communicating with AWS S3."""
     IMDSV1_FALLBACK: str
+    """Fall back to ImdsV1"""
     METADATA_ENDPOINT: str
+    """Set the instance metadata endpoint"""
     REGION: str
+    """Region"""
     REQUEST_PAYER: str
+    """If `True`, enable operations on requester-pays buckets."""
     S3_EXPRESS: str
+    """Enable Support for S3 Express One Zone"""
     SECRET_ACCESS_KEY: str
+    """Secret Access Key"""
     SESSION_TOKEN: str
+    """Token to use for requests (passed to underlying provider)"""
     SKIP_SIGNATURE: str
     TOKEN: str
+    """Token to use for requests (passed to underlying provider)"""
     UNSIGNED_PAYLOAD: str
+    """Avoid computing payload checksum when calculating signature."""
     VIRTUAL_HOSTED_STYLE_REQUEST: str
-
-"""Valid AWS S3 configuration keys.
-
-Either lower case or upper case strings are accepted.
-
-- `aws_access_key_id`, `access_key_id`: AWS Access Key
-- `aws_secret_access_key`, `secret_access_key`: Secret Access Key
-- `aws_region`, `region`: Region
-- `aws_request_payer`, `request_payer`: if `True`, enable operations on requester-pays buckets.
-- `aws_default_region`, `default_region`: Default region
-- `aws_bucket`, `aws_bucket_name`, `bucket`, `bucket_name`: Bucket name
-- `aws_endpoint`, `aws_endpoint_url`, `endpoint`, `endpoint_url`: Sets custom endpoint for communicating with AWS S3.
-- `aws_session_token`, `aws_token`, `session_token`, `token`: Token to use for requests (passed to underlying provider)
-- `aws_imdsv1_fallback`, `imdsv1_fallback`: Fall back to ImdsV1
-- `aws_virtual_hosted_style_request`, `virtual_hosted_style_request`: If virtual hosted style request has to be used
-- `aws_unsigned_payload`, `unsigned_payload`: Avoid computing payload checksum when calculating signature.
-- `aws_metadata_endpoint`, `metadata_endpoint`: Set the instance metadata endpoint
-- `aws_disable_tagging`, `disable_tagging`: Disable tagging objects. This can be desirable if not supported by the backing store.
-- `aws_s3_express`, `s3_express`: Enable Support for S3 Express One Zone
-"""
+    """If virtual hosted style request has to be used."""
 
 class S3Store:
     """

--- a/obstore/python/obstore/store/_aws.pyi
+++ b/obstore/python/obstore/store/_aws.pyi
@@ -1,11 +1,11 @@
-from typing import Dict, TypedDict, Unpack
+from typing import TypedDict, Unpack
 
 import boto3
 import boto3.session
 import botocore
 import botocore.session
 
-from ._client import ClientConfigKey
+from ._client import ClientConfig
 from ._retry import RetryConfig
 
 # Note: we removed `bucket` because it overlaps with an existing named arg in the
@@ -205,7 +205,7 @@ class S3Store:
         bucket: str,
         *,
         config: S3Config | None = None,
-        client_options: Dict[ClientConfigKey, str | bool] | None = None,
+        client_options: ClientConfig | None = None,
         retry_config: RetryConfig | None = None,
         **kwargs: Unpack[S3Config],
     ) -> None:
@@ -229,7 +229,7 @@ class S3Store:
         bucket: str | None = None,
         *,
         config: S3Config | None = None,
-        client_options: Dict[ClientConfigKey, str | bool] | None = None,
+        client_options: ClientConfig | None = None,
         retry_config: RetryConfig | None = None,
         **kwargs: Unpack[S3Config],
     ) -> S3Store:
@@ -269,7 +269,7 @@ class S3Store:
         bucket: str,
         *,
         config: S3Config | None = None,
-        client_options: Dict[ClientConfigKey, str | bool] | None = None,
+        client_options: ClientConfig | None = None,
         retry_config: RetryConfig | None = None,
         **kwargs: Unpack[S3Config],
     ) -> S3Store:
@@ -309,7 +309,7 @@ class S3Store:
         url: str,
         *,
         config: S3Config | None = None,
-        client_options: Dict[ClientConfigKey, str | bool] | None = None,
+        client_options: ClientConfig | None = None,
         retry_config: RetryConfig | None = None,
         **kwargs: Unpack[S3Config],
     ) -> S3Store:

--- a/obstore/python/obstore/store/_aws.pyi
+++ b/obstore/python/obstore/store/_aws.pyi
@@ -21,7 +21,7 @@ class S3Config(TypedDict, total=False):
     """AWS Access Key"""
     aws_access_key_id: str
     """AWS Access Key"""
-    aws_allow_http: str
+    aws_allow_http: bool
     aws_bucket_name: str
     """Bucket name"""
     aws_bucket: str
@@ -32,7 +32,7 @@ class S3Config(TypedDict, total=False):
     aws_copy_if_not_exists: str
     aws_default_region: str
     """Default region"""
-    aws_disable_tagging: str
+    aws_disable_tagging: bool
     """Disable tagging objects. This can be desirable if not supported by the backing store."""
     aws_endpoint_url: str
     """Sets custom endpoint for communicating with AWS S3."""
@@ -44,23 +44,24 @@ class S3Config(TypedDict, total=False):
     """Set the instance metadata endpoint"""
     aws_region: str
     """Region"""
-    aws_request_payer: str
+    aws_request_payer: bool
     """If `True`, enable operations on requester-pays buckets."""
-    aws_s3_express: str
+    aws_s3_express: bool
     """Enable Support for S3 Express One Zone"""
     aws_secret_access_key: str
     """Secret Access Key"""
     aws_server_side_encryption: str
     aws_session_token: str
     """Token to use for requests (passed to underlying provider)"""
-    aws_skip_signature: str
-    aws_sse_bucket_key_enabled: str
+    aws_skip_signature: bool
+    """If `True`, S3Store will not fetch credentials and will not sign requests."""
+    aws_sse_bucket_key_enabled: bool
     aws_sse_kms_key_id: str
     aws_token: str
     """Token to use for requests (passed to underlying provider)"""
-    aws_unsigned_payload: str
+    aws_unsigned_payload: bool
     """Avoid computing payload checksum when calculating signature."""
-    aws_virtual_hosted_style_request: str
+    aws_virtual_hosted_style_request: bool
     """If virtual hosted style request has to be used."""
     bucket_name: str
     """Bucket name"""
@@ -69,7 +70,7 @@ class S3Config(TypedDict, total=False):
     copy_if_not_exists: str
     default_region: str
     """Default region"""
-    disable_tagging: str
+    disable_tagging: bool
     """Disable tagging objects. This can be desirable if not supported by the backing store."""
     endpoint_url: str
     """Sets custom endpoint for communicating with AWS S3."""
@@ -81,26 +82,27 @@ class S3Config(TypedDict, total=False):
     """Set the instance metadata endpoint"""
     region: str
     """Region"""
-    request_payer: str
+    request_payer: bool
     """If `True`, enable operations on requester-pays buckets."""
-    s3_express: str
+    s3_express: bool
     """Enable Support for S3 Express One Zone"""
     secret_access_key: str
     """Secret Access Key"""
     session_token: str
     """Token to use for requests (passed to underlying provider)"""
-    skip_signature: str
+    skip_signature: bool
+    """If `True`, S3Store will not fetch credentials and will not sign requests."""
     token: str
     """Token to use for requests (passed to underlying provider)"""
-    unsigned_payload: str
+    unsigned_payload: bool
     """Avoid computing payload checksum when calculating signature."""
-    virtual_hosted_style_request: str
+    virtual_hosted_style_request: bool
     """If virtual hosted style request has to be used."""
     ACCESS_KEY_ID: str
     """AWS Access Key"""
     AWS_ACCESS_KEY_ID: str
     """AWS Access Key"""
-    AWS_ALLOW_HTTP: str
+    AWS_ALLOW_HTTP: bool
     AWS_BUCKET_NAME: str
     """Bucket name"""
     AWS_BUCKET: str
@@ -111,7 +113,7 @@ class S3Config(TypedDict, total=False):
     AWS_COPY_IF_NOT_EXISTS: str
     AWS_DEFAULT_REGION: str
     """Default region"""
-    AWS_DISABLE_TAGGING: str
+    AWS_DISABLE_TAGGING: bool
     """Disable tagging objects. This can be desirable if not supported by the backing store."""
     AWS_ENDPOINT_URL: str
     """Sets custom endpoint for communicating with AWS S3."""
@@ -123,7 +125,7 @@ class S3Config(TypedDict, total=False):
     """Set the instance metadata endpoint"""
     AWS_REGION: str
     """Region"""
-    AWS_REQUEST_PAYER: str
+    AWS_REQUEST_PAYER: bool
     """If `True`, enable operations on requester-pays buckets."""
     AWS_S3_EXPRESS: str
     """Enable Support for S3 Express One Zone"""
@@ -132,14 +134,15 @@ class S3Config(TypedDict, total=False):
     AWS_SERVER_SIDE_ENCRYPTION: str
     AWS_SESSION_TOKEN: str
     """Token to use for requests (passed to underlying provider)"""
-    AWS_SKIP_SIGNATURE: str
-    AWS_SSE_BUCKET_KEY_ENABLED: str
+    AWS_SKIP_SIGNATURE: bool
+    """If `True`, S3Store will not fetch credentials and will not sign requests."""
+    AWS_SSE_BUCKET_KEY_ENABLED: bool
     AWS_SSE_KMS_KEY_ID: str
     AWS_TOKEN: str
     """Token to use for requests (passed to underlying provider)"""
-    AWS_UNSIGNED_PAYLOAD: str
+    AWS_UNSIGNED_PAYLOAD: bool
     """Avoid computing payload checksum when calculating signature."""
-    AWS_VIRTUAL_HOSTED_STYLE_REQUEST: str
+    AWS_VIRTUAL_HOSTED_STYLE_REQUEST: bool
     """If virtual hosted style request has to be used."""
     BUCKET_NAME: str
     """Bucket name"""
@@ -150,7 +153,7 @@ class S3Config(TypedDict, total=False):
     COPY_IF_NOT_EXISTS: str
     DEFAULT_REGION: str
     """Default region"""
-    DISABLE_TAGGING: str
+    DISABLE_TAGGING: bool
     """Disable tagging objects. This can be desirable if not supported by the backing store."""
     ENDPOINT_URL: str
     """Sets custom endpoint for communicating with AWS S3."""
@@ -162,7 +165,7 @@ class S3Config(TypedDict, total=False):
     """Set the instance metadata endpoint"""
     REGION: str
     """Region"""
-    REQUEST_PAYER: str
+    REQUEST_PAYER: bool
     """If `True`, enable operations on requester-pays buckets."""
     S3_EXPRESS: str
     """Enable Support for S3 Express One Zone"""
@@ -170,12 +173,13 @@ class S3Config(TypedDict, total=False):
     """Secret Access Key"""
     SESSION_TOKEN: str
     """Token to use for requests (passed to underlying provider)"""
-    SKIP_SIGNATURE: str
+    SKIP_SIGNATURE: bool
+    """If `True`, S3Store will not fetch credentials and will not sign requests."""
     TOKEN: str
     """Token to use for requests (passed to underlying provider)"""
-    UNSIGNED_PAYLOAD: str
+    UNSIGNED_PAYLOAD: bool
     """Avoid computing payload checksum when calculating signature."""
-    VIRTUAL_HOSTED_STYLE_REQUEST: str
+    VIRTUAL_HOSTED_STYLE_REQUEST: bool
     """If virtual hosted style request has to be used."""
 
 class S3Store:
@@ -187,12 +191,13 @@ class S3Store:
 
     **Using requester-pays buckets**:
 
-    Include `'AWS_REQUESTER_PAYS': True` as an element in the `config`. Or, if you're
-    using `S3Store.from_env`, have `AWS_REQUESTER_PAYS=True` set in the environment.
+    Pass `request_payer=True` as a keyword argument. Or, if you're using
+    `S3Store.from_env`, have `AWS_REQUESTER_PAYS=True` set in the environment.
 
     **Anonymous requests**:
 
-    Pass `skip_signature=True` as a keyword argument.
+    Pass `skip_signature=True` as a keyword argument. Or, if you're using
+    `S3Store.from_env`, have `AWS_SKIP_SIGNATURE=True` set in the environment.
     """
 
     def __init__(
@@ -226,6 +231,7 @@ class S3Store:
         config: S3Config | None = None,
         client_options: Dict[ClientConfigKey, str | bool] | None = None,
         retry_config: RetryConfig | None = None,
+        **kwargs: Unpack[S3Config],
     ) -> S3Store:
         """Construct a new S3Store with regular AWS environment variables
 
@@ -265,13 +271,16 @@ class S3Store:
         config: S3Config | None = None,
         client_options: Dict[ClientConfigKey, str | bool] | None = None,
         retry_config: RetryConfig | None = None,
+        **kwargs: Unpack[S3Config],
     ) -> S3Store:
         """Construct a new S3Store with credentials inferred from a boto3 Session
+
+        This can be useful to read S3 credentials from [disk-based credentials sources](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html).
 
         !!! note
             This is a convenience function for users who are already using `boto3` or
             `botocore`. If you're not already using `boto3` or `botocore`, use other
-            classmethods, which do not need `boto3` or `botocore` to be installed.
+            constructors, which do not need `boto3` or `botocore` to be installed.
 
         Examples:
 
@@ -279,11 +288,7 @@ class S3Store:
         import boto3
 
         session = boto3.Session()
-        store = S3Store.from_session(
-            session,
-            "bucket-name",
-            config={"AWS_REGION": "us-east-1"},
-        )
+        store = S3Store.from_session(session, "bucket-name", region="us-east-1")
         ```
 
         Args:
@@ -306,6 +311,7 @@ class S3Store:
         config: S3Config | None = None,
         client_options: Dict[ClientConfigKey, str | bool] | None = None,
         retry_config: RetryConfig | None = None,
+        **kwargs: Unpack[S3Config],
     ) -> S3Store:
         """
         Parse available connection info from a well-known storage URL.

--- a/obstore/python/obstore/store/_aws.pyi
+++ b/obstore/python/obstore/store/_aws.pyi
@@ -136,6 +136,10 @@ class S3Store:
 
     Include `'AWS_REQUESTER_PAYS': True` as an element in the `config`. Or, if you're
     using `S3Store.from_env`, have `AWS_REQUESTER_PAYS=True` set in the environment.
+
+    **Anonymous requests**:
+
+    Pass `skip_signature=True` as a keyword argument.
     """
 
     def __init__(
@@ -148,30 +152,6 @@ class S3Store:
         **kwargs: Unpack[S3Config],
     ) -> None:
         """Create a new S3Store
-
-        Args:
-            bucket: The AWS bucket to use.
-
-        Keyword Args:
-            config: AWS Configuration. Values in this config will override values inferred from the environment. Defaults to None.
-            client_options: HTTP Client options. Defaults to None.
-            retry_config: Retry configuration. Defaults to None.
-
-        Returns:
-            S3Store
-        """
-
-    @classmethod
-    def anon(
-        cls,
-        bucket: str,
-        *,
-        config: S3Config | None = None,
-        client_options: Dict[ClientConfigKey, str | bool] | None = None,
-        retry_config: RetryConfig | None = None,
-        **kwargs: Unpack[S3Config],
-    ) -> S3Store:
-        """Construct a new anonymous S3Store.
 
         Args:
             bucket: The AWS bucket to use.

--- a/obstore/python/obstore/store/_aws.pyi
+++ b/obstore/python/obstore/store/_aws.pyi
@@ -1,4 +1,4 @@
-from typing import Dict, Literal
+from typing import Dict, TypedDict, Unpack
 
 import boto3
 import boto3.session
@@ -8,102 +8,103 @@ import botocore.session
 from ._client import ClientConfigKey
 from ._retry import RetryConfig
 
-S3ConfigKey = Literal[
-    "access_key_id",
-    "aws_access_key_id",
-    "aws_allow_http",
-    "aws_bucket_name",
-    "aws_bucket",
-    "aws_checksum_algorithm",
-    "aws_conditional_put",
-    "aws_container_credentials_relative_uri",
-    "aws_copy_if_not_exists",
-    "aws_default_region",
-    "aws_disable_tagging",
-    "aws_endpoint_url",
-    "aws_endpoint",
-    "aws_imdsv1_fallback",
-    "aws_metadata_endpoint",
-    "aws_region",
-    "aws_request_payer",
-    "aws_s3_express",
-    "aws_secret_access_key",
-    "aws_server_side_encryption",
-    "aws_session_token",
-    "aws_skip_signature",
-    "aws_sse_bucket_key_enabled",
-    "aws_sse_kms_key_id",
-    "aws_token",
-    "aws_unsigned_payload",
-    "aws_virtual_hosted_style_request",
-    "bucket_name",
-    "bucket",
-    "checksum_algorithm",
-    "conditional_put",
-    "copy_if_not_exists",
-    "default_region",
-    "disable_tagging",
-    "endpoint_url",
-    "endpoint",
-    "imdsv1_fallback",
-    "metadata_endpoint",
-    "region",
-    "request_payer",
-    "s3_express",
-    "secret_access_key",
-    "session_token",
-    "skip_signature",
-    "token",
-    "unsigned_payload",
-    "virtual_hosted_style_request",
-    "ACCESS_KEY_ID",
-    "AWS_ACCESS_KEY_ID",
-    "AWS_ALLOW_HTTP",
-    "AWS_BUCKET_NAME",
-    "AWS_BUCKET",
-    "AWS_CHECKSUM_ALGORITHM",
-    "AWS_CONDITIONAL_PUT",
-    "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
-    "AWS_COPY_IF_NOT_EXISTS",
-    "AWS_DEFAULT_REGION",
-    "AWS_DISABLE_TAGGING",
-    "AWS_ENDPOINT_URL",
-    "AWS_ENDPOINT",
-    "AWS_IMDSV1_FALLBACK",
-    "AWS_METADATA_ENDPOINT",
-    "AWS_REGION",
-    "AWS_REQUEST_PAYER",
-    "AWS_S3_EXPRESS",
-    "AWS_SECRET_ACCESS_KEY",
-    "AWS_SERVER_SIDE_ENCRYPTION",
-    "AWS_SESSION_TOKEN",
-    "AWS_SKIP_SIGNATURE",
-    "AWS_SSE_BUCKET_KEY_ENABLED",
-    "AWS_SSE_KMS_KEY_ID",
-    "AWS_TOKEN",
-    "AWS_UNSIGNED_PAYLOAD",
-    "AWS_VIRTUAL_HOSTED_STYLE_REQUEST",
-    "BUCKET_NAME",
-    "BUCKET",
-    "CHECKSUM_ALGORITHM",
-    "CONDITIONAL_PUT",
-    "COPY_IF_NOT_EXISTS",
-    "DEFAULT_REGION",
-    "DISABLE_TAGGING",
-    "ENDPOINT_URL",
-    "ENDPOINT",
-    "IMDSV1_FALLBACK",
-    "METADATA_ENDPOINT",
-    "REGION",
-    "REQUEST_PAYER",
-    "S3_EXPRESS",
-    "SECRET_ACCESS_KEY",
-    "SESSION_TOKEN",
-    "SKIP_SIGNATURE",
-    "TOKEN",
-    "UNSIGNED_PAYLOAD",
-    "VIRTUAL_HOSTED_STYLE_REQUEST",
-]
+# Note: we removed `bucket` because it overlaps with an existing named arg in the
+# constructors
+class S3Config(TypedDict, total=False):
+    access_key_id: str
+    aws_access_key_id: str
+    aws_allow_http: str
+    aws_bucket_name: str
+    aws_bucket: str
+    aws_checksum_algorithm: str
+    aws_conditional_put: str
+    aws_container_credentials_relative_uri: str
+    aws_copy_if_not_exists: str
+    aws_default_region: str
+    aws_disable_tagging: str
+    aws_endpoint_url: str
+    aws_endpoint: str
+    aws_imdsv1_fallback: str
+    aws_metadata_endpoint: str
+    aws_region: str
+    aws_request_payer: str
+    aws_s3_express: str
+    aws_secret_access_key: str
+    aws_server_side_encryption: str
+    aws_session_token: str
+    aws_skip_signature: str
+    aws_sse_bucket_key_enabled: str
+    aws_sse_kms_key_id: str
+    aws_token: str
+    aws_unsigned_payload: str
+    aws_virtual_hosted_style_request: str
+    bucket_name: str
+    checksum_algorithm: str
+    conditional_put: str
+    copy_if_not_exists: str
+    default_region: str
+    disable_tagging: str
+    endpoint_url: str
+    endpoint: str
+    imdsv1_fallback: str
+    metadata_endpoint: str
+    region: str
+    request_payer: str
+    s3_express: str
+    secret_access_key: str
+    session_token: str
+    skip_signature: str
+    token: str
+    unsigned_payload: str
+    virtual_hosted_style_request: str
+    ACCESS_KEY_ID: str
+    AWS_ACCESS_KEY_ID: str
+    AWS_ALLOW_HTTP: str
+    AWS_BUCKET_NAME: str
+    AWS_BUCKET: str
+    AWS_CHECKSUM_ALGORITHM: str
+    AWS_CONDITIONAL_PUT: str
+    AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: str
+    AWS_COPY_IF_NOT_EXISTS: str
+    AWS_DEFAULT_REGION: str
+    AWS_DISABLE_TAGGING: str
+    AWS_ENDPOINT_URL: str
+    AWS_ENDPOINT: str
+    AWS_IMDSV1_FALLBACK: str
+    AWS_METADATA_ENDPOINT: str
+    AWS_REGION: str
+    AWS_REQUEST_PAYER: str
+    AWS_S3_EXPRESS: str
+    AWS_SECRET_ACCESS_KEY: str
+    AWS_SERVER_SIDE_ENCRYPTION: str
+    AWS_SESSION_TOKEN: str
+    AWS_SKIP_SIGNATURE: str
+    AWS_SSE_BUCKET_KEY_ENABLED: str
+    AWS_SSE_KMS_KEY_ID: str
+    AWS_TOKEN: str
+    AWS_UNSIGNED_PAYLOAD: str
+    AWS_VIRTUAL_HOSTED_STYLE_REQUEST: str
+    BUCKET_NAME: str
+    BUCKET: str
+    CHECKSUM_ALGORITHM: str
+    CONDITIONAL_PUT: str
+    COPY_IF_NOT_EXISTS: str
+    DEFAULT_REGION: str
+    DISABLE_TAGGING: str
+    ENDPOINT_URL: str
+    ENDPOINT: str
+    IMDSV1_FALLBACK: str
+    METADATA_ENDPOINT: str
+    REGION: str
+    REQUEST_PAYER: str
+    S3_EXPRESS: str
+    SECRET_ACCESS_KEY: str
+    SESSION_TOKEN: str
+    SKIP_SIGNATURE: str
+    TOKEN: str
+    UNSIGNED_PAYLOAD: str
+    VIRTUAL_HOSTED_STYLE_REQUEST: str
+
 """Valid AWS S3 configuration keys.
 
 Either lower case or upper case strings are accepted.
@@ -141,9 +142,10 @@ class S3Store:
         self,
         bucket: str,
         *,
-        config: Dict[S3ConfigKey | str, str] | None = None,
+        config: S3Config | None = None,
         client_options: Dict[ClientConfigKey, str | bool] | None = None,
         retry_config: RetryConfig | None = None,
+        **kwargs: Unpack[S3Config],
     ) -> None:
         """Create a new S3Store
 
@@ -164,9 +166,10 @@ class S3Store:
         cls,
         bucket: str,
         *,
-        config: Dict[S3ConfigKey | str, str] | None = None,
+        config: S3Config | None = None,
         client_options: Dict[ClientConfigKey, str | bool] | None = None,
         retry_config: RetryConfig | None = None,
+        **kwargs: Unpack[S3Config],
     ) -> S3Store:
         """Construct a new anonymous S3Store.
 
@@ -187,7 +190,7 @@ class S3Store:
         cls,
         bucket: str | None = None,
         *,
-        config: Dict[S3ConfigKey | str, str] | None = None,
+        config: S3Config | None = None,
         client_options: Dict[ClientConfigKey, str | bool] | None = None,
         retry_config: RetryConfig | None = None,
     ) -> S3Store:
@@ -226,7 +229,7 @@ class S3Store:
         session: boto3.session.Session | botocore.session.Session,
         bucket: str,
         *,
-        config: Dict[S3ConfigKey | str, str] | None = None,
+        config: S3Config | None = None,
         client_options: Dict[ClientConfigKey, str | bool] | None = None,
         retry_config: RetryConfig | None = None,
     ) -> S3Store:
@@ -267,7 +270,7 @@ class S3Store:
         cls,
         url: str,
         *,
-        config: Dict[S3ConfigKey | str, str] | None = None,
+        config: S3Config | None = None,
         client_options: Dict[ClientConfigKey, str | bool] | None = None,
         retry_config: RetryConfig | None = None,
     ) -> S3Store:

--- a/obstore/python/obstore/store/_azure.pyi
+++ b/obstore/python/obstore/store/_azure.pyi
@@ -1,6 +1,6 @@
-from typing import Dict, TypedDict, Unpack
+from typing import TypedDict, Unpack
 
-from ._client import ClientConfigKey
+from ._client import ClientConfig
 from ._retry import RetryConfig
 
 class AzureConfig(TypedDict, total=False):
@@ -267,7 +267,7 @@ class AzureStore:
         container: str,
         *,
         config: AzureConfig | None = None,
-        client_options: Dict[ClientConfigKey, str | bool] | None = None,
+        client_options: ClientConfig | None = None,
         retry_config: RetryConfig | None = None,
         **kwargs: Unpack[AzureConfig],
     ) -> None:
@@ -291,7 +291,7 @@ class AzureStore:
         container: str,
         *,
         config: AzureConfig | None = None,
-        client_options: Dict[ClientConfigKey, str | bool] | None = None,
+        client_options: ClientConfig | None = None,
         retry_config: RetryConfig | None = None,
         **kwargs: Unpack[AzureConfig],
     ) -> AzureStore:
@@ -324,7 +324,7 @@ class AzureStore:
         url: str,
         *,
         config: AzureConfig | None = None,
-        client_options: Dict[ClientConfigKey, str | bool] | None = None,
+        client_options: ClientConfig | None = None,
         retry_config: RetryConfig | None = None,
         **kwargs: Unpack[AzureConfig],
     ) -> AzureStore:

--- a/obstore/python/obstore/store/_azure.pyi
+++ b/obstore/python/obstore/store/_azure.pyi
@@ -1,114 +1,114 @@
-from typing import Dict, Literal
+from typing import Dict, TypedDict, Unpack
 
 from ._client import ClientConfigKey
 from ._retry import RetryConfig
 
-AzureConfigKey = Literal[
-    "access_key",
-    "account_key",
-    "account_name",
-    "authority_id",
-    "azure_authority_id",
-    "azure_client_id",
-    "azure_client_secret",
-    "azure_container_name",
-    "azure_disable_tagging",
-    "azure_endpoint",
-    "azure_federated_token_file",
-    "azure_identity_endpoint",
-    "azure_msi_endpoint",
-    "azure_msi_resource_id",
-    "azure_object_id",
-    "azure_skip_signature",
-    "azure_storage_access_key",
-    "azure_storage_account_key",
-    "azure_storage_account_name",
-    "azure_storage_authority_id",
-    "azure_storage_client_id",
-    "azure_storage_client_secret",
-    "azure_storage_endpoint",
-    "azure_storage_master_key",
-    "azure_storage_sas_key",
-    "azure_storage_sas_token",
-    "azure_storage_tenant_id",
-    "azure_storage_token",
-    "azure_storage_use_emulator",
-    "azure_tenant_id",
-    "azure_use_azure_cli",
-    "azure_use_fabric_endpoint",
-    "bearer_token",
-    "client_id",
-    "client_secret",
-    "container_name",
-    "disable_tagging",
-    "endpoint",
-    "federated_token_file",
-    "identity_endpoint",
-    "master_key",
-    "msi_endpoint",
-    "msi_resource_id",
-    "object_id",
-    "sas_key",
-    "sas_token",
-    "skip_signature",
-    "tenant_id",
-    "token",
-    "use_azure_cli",
-    "use_emulator",
-    "use_fabric_endpoint",
-    "ACCESS_KEY",
-    "ACCOUNT_KEY",
-    "ACCOUNT_NAME",
-    "AUTHORITY_ID",
-    "AZURE_AUTHORITY_ID",
-    "AZURE_CLIENT_ID",
-    "AZURE_CLIENT_SECRET",
-    "AZURE_CONTAINER_NAME",
-    "AZURE_DISABLE_TAGGING",
-    "AZURE_ENDPOINT",
-    "AZURE_FEDERATED_TOKEN_FILE",
-    "AZURE_IDENTITY_ENDPOINT",
-    "AZURE_MSI_ENDPOINT",
-    "AZURE_MSI_RESOURCE_ID",
-    "AZURE_OBJECT_ID",
-    "AZURE_SKIP_SIGNATURE",
-    "AZURE_STORAGE_ACCESS_KEY",
-    "AZURE_STORAGE_ACCOUNT_KEY",
-    "AZURE_STORAGE_ACCOUNT_NAME",
-    "AZURE_STORAGE_AUTHORITY_ID",
-    "AZURE_STORAGE_CLIENT_ID",
-    "AZURE_STORAGE_CLIENT_SECRET",
-    "AZURE_STORAGE_ENDPOINT",
-    "AZURE_STORAGE_MASTER_KEY",
-    "AZURE_STORAGE_SAS_KEY",
-    "AZURE_STORAGE_SAS_TOKEN",
-    "AZURE_STORAGE_TENANT_ID",
-    "AZURE_STORAGE_TOKEN",
-    "AZURE_STORAGE_USE_EMULATOR",
-    "AZURE_TENANT_ID",
-    "AZURE_USE_AZURE_CLI",
-    "AZURE_USE_FABRIC_ENDPOINT",
-    "BEARER_TOKEN",
-    "CLIENT_ID",
-    "CLIENT_SECRET",
-    "CONTAINER_NAME",
-    "DISABLE_TAGGING",
-    "ENDPOINT",
-    "FEDERATED_TOKEN_FILE",
-    "IDENTITY_ENDPOINT",
-    "MASTER_KEY",
-    "MSI_ENDPOINT",
-    "MSI_RESOURCE_ID",
-    "OBJECT_ID",
-    "SAS_KEY",
-    "SAS_TOKEN",
-    "SKIP_SIGNATURE",
-    "TENANT_ID",
-    "TOKEN",
-    "USE_AZURE_CLI",
-    "USE_EMULATOR",
-    "USE_FABRIC_ENDPOINT",
-]
+class AzureConfig(TypedDict, total=False):
+    access_key: str
+    account_key: str
+    account_name: str
+    authority_id: str
+    azure_authority_id: str
+    azure_client_id: str
+    azure_client_secret: str
+    azure_container_name: str
+    azure_disable_tagging: str
+    azure_endpoint: str
+    azure_federated_token_file: str
+    azure_identity_endpoint: str
+    azure_msi_endpoint: str
+    azure_msi_resource_id: str
+    azure_object_id: str
+    azure_skip_signature: str
+    azure_storage_access_key: str
+    azure_storage_account_key: str
+    azure_storage_account_name: str
+    azure_storage_authority_id: str
+    azure_storage_client_id: str
+    azure_storage_client_secret: str
+    azure_storage_endpoint: str
+    azure_storage_master_key: str
+    azure_storage_sas_key: str
+    azure_storage_sas_token: str
+    azure_storage_tenant_id: str
+    azure_storage_token: str
+    azure_storage_use_emulator: str
+    azure_tenant_id: str
+    azure_use_azure_cli: str
+    azure_use_fabric_endpoint: str
+    bearer_token: str
+    client_id: str
+    client_secret: str
+    container_name: str
+    disable_tagging: str
+    endpoint: str
+    federated_token_file: str
+    identity_endpoint: str
+    master_key: str
+    msi_endpoint: str
+    msi_resource_id: str
+    object_id: str
+    sas_key: str
+    sas_token: str
+    skip_signature: str
+    tenant_id: str
+    token: str
+    use_azure_cli: str
+    use_emulator: str
+    use_fabric_endpoint: str
+    ACCESS_KEY: str
+    ACCOUNT_KEY: str
+    ACCOUNT_NAME: str
+    AUTHORITY_ID: str
+    AZURE_AUTHORITY_ID: str
+    AZURE_CLIENT_ID: str
+    AZURE_CLIENT_SECRET: str
+    AZURE_CONTAINER_NAME: str
+    AZURE_DISABLE_TAGGING: str
+    AZURE_ENDPOINT: str
+    AZURE_FEDERATED_TOKEN_FILE: str
+    AZURE_IDENTITY_ENDPOINT: str
+    AZURE_MSI_ENDPOINT: str
+    AZURE_MSI_RESOURCE_ID: str
+    AZURE_OBJECT_ID: str
+    AZURE_SKIP_SIGNATURE: str
+    AZURE_STORAGE_ACCESS_KEY: str
+    AZURE_STORAGE_ACCOUNT_KEY: str
+    AZURE_STORAGE_ACCOUNT_NAME: str
+    AZURE_STORAGE_AUTHORITY_ID: str
+    AZURE_STORAGE_CLIENT_ID: str
+    AZURE_STORAGE_CLIENT_SECRET: str
+    AZURE_STORAGE_ENDPOINT: str
+    AZURE_STORAGE_MASTER_KEY: str
+    AZURE_STORAGE_SAS_KEY: str
+    AZURE_STORAGE_SAS_TOKEN: str
+    AZURE_STORAGE_TENANT_ID: str
+    AZURE_STORAGE_TOKEN: str
+    AZURE_STORAGE_USE_EMULATOR: str
+    AZURE_TENANT_ID: str
+    AZURE_USE_AZURE_CLI: str
+    AZURE_USE_FABRIC_ENDPOINT: str
+    BEARER_TOKEN: str
+    CLIENT_ID: str
+    CLIENT_SECRET: str
+    CONTAINER_NAME: str
+    DISABLE_TAGGING: str
+    ENDPOINT: str
+    FEDERATED_TOKEN_FILE: str
+    IDENTITY_ENDPOINT: str
+    MASTER_KEY: str
+    MSI_ENDPOINT: str
+    MSI_RESOURCE_ID: str
+    OBJECT_ID: str
+    SAS_KEY: str
+    SAS_TOKEN: str
+    SKIP_SIGNATURE: str
+    TENANT_ID: str
+    TOKEN: str
+    USE_AZURE_CLI: str
+    USE_EMULATOR: str
+    USE_FABRIC_ENDPOINT: str
+
 """Valid Azure storage configuration keys
 
 Either lower case or upper case strings are accepted.
@@ -143,9 +143,10 @@ class AzureStore:
         self,
         container: str,
         *,
-        config: Dict[AzureConfigKey, str] | None = None,
+        config: AzureConfig | None = None,
         client_options: Dict[ClientConfigKey, str | bool] | None = None,
         retry_config: RetryConfig | None = None,
+        **kwargs: Unpack[AzureConfig],
     ) -> None:
         """Construct a new AzureStore.
 
@@ -166,9 +167,10 @@ class AzureStore:
         cls,
         container: str,
         *,
-        config: Dict[AzureConfigKey, str] | None = None,
+        config: AzureConfig | None = None,
         client_options: Dict[ClientConfigKey, str | bool] | None = None,
         retry_config: RetryConfig | None = None,
+        **kwargs: Unpack[AzureConfig],
     ) -> AzureStore:
         """Construct a new AzureStore with values pre-populated from environment variables.
 
@@ -198,9 +200,10 @@ class AzureStore:
         cls,
         url: str,
         *,
-        config: Dict[AzureConfigKey, str] | None = None,
+        config: AzureConfig | None = None,
         client_options: Dict[ClientConfigKey, str | bool] | None = None,
         retry_config: RetryConfig | None = None,
+        **kwargs: Unpack[AzureConfig],
     ) -> AzureStore:
         """Construct a new AzureStore with values populated from a well-known storage URL.
 

--- a/obstore/python/obstore/store/_azure.pyi
+++ b/obstore/python/obstore/store/_azure.pyi
@@ -4,137 +4,260 @@ from ._client import ClientConfigKey
 from ._retry import RetryConfig
 
 class AzureConfig(TypedDict, total=False):
+    """Configuration parameters for AzureStore.
+
+    There are duplicates of many parameters, and parameters can be either upper or lower
+    case. Not all parameters are required.
+    """
+
     access_key: str
+    """Master key for accessing storage account"""
     account_key: str
+    """Master key for accessing storage account"""
     account_name: str
+    """The name of the azure storage account"""
     authority_id: str
+    """Tenant id used in oauth flows"""
     azure_authority_id: str
+    """Tenant id used in oauth flows"""
     azure_client_id: str
+    """Service principal client id for authorizing requests"""
     azure_client_secret: str
+    """Service principal client secret for authorizing requests"""
     azure_container_name: str
+    """Container name"""
     azure_disable_tagging: str
+    """Disables tagging objects"""
     azure_endpoint: str
+    """Override the endpoint used to communicate with blob storage"""
     azure_federated_token_file: str
+    """File containing token for Azure AD workload identity federation"""
     azure_identity_endpoint: str
+    """Endpoint to request a imds managed identity token"""
     azure_msi_endpoint: str
+    """Endpoint to request a imds managed identity token"""
     azure_msi_resource_id: str
+    """Msi resource id for use with managed identity authentication"""
     azure_object_id: str
+    """Object id for use with managed identity authentication"""
     azure_skip_signature: str
+    """Skip signing requests"""
     azure_storage_access_key: str
+    """Master key for accessing storage account"""
     azure_storage_account_key: str
+    """Master key for accessing storage account"""
     azure_storage_account_name: str
+    """The name of the azure storage account"""
     azure_storage_authority_id: str
+    """Tenant id used in oauth flows"""
     azure_storage_client_id: str
+    """Service principal client id for authorizing requests"""
     azure_storage_client_secret: str
+    """Service principal client secret for authorizing requests"""
     azure_storage_endpoint: str
+    """Override the endpoint used to communicate with blob storage"""
     azure_storage_master_key: str
+    """Master key for accessing storage account"""
     azure_storage_sas_key: str
+    """
+    Shared access signature.
+
+    The signature is expected to be percent-encoded, `much `like they are provided in
+    the azure storage explorer or azure portal.
+    """
     azure_storage_sas_token: str
+    """
+    Shared access signature.
+
+    The signature is expected to be percent-encoded, `much `like they are provided in
+    the azure storage explorer or azure portal.
+    """
     azure_storage_tenant_id: str
+    """Tenant id used in oauth flows"""
     azure_storage_token: str
+    """Bearer token"""
     azure_storage_use_emulator: str
+    """Use object store with azurite storage emulator"""
     azure_tenant_id: str
+    """Tenant id used in oauth flows"""
     azure_use_azure_cli: str
+    """Use azure cli for acquiring access token"""
     azure_use_fabric_endpoint: str
+    """Use object store with url scheme account.dfs.fabric.microsoft.com"""
     bearer_token: str
+    """Bearer token"""
     client_id: str
+    """Service principal client id for authorizing requests"""
     client_secret: str
+    """Service principal client secret for authorizing requests"""
     container_name: str
+    """Container name"""
     disable_tagging: str
+    """Disables tagging objects"""
     endpoint: str
+    """Override the endpoint used to communicate with blob storage"""
     federated_token_file: str
+    """File containing token for Azure AD workload identity federation"""
     identity_endpoint: str
+    """Endpoint to request a imds managed identity token"""
     master_key: str
+    """Master key for accessing storage account"""
     msi_endpoint: str
+    """Endpoint to request a imds managed identity token"""
     msi_resource_id: str
+    """Msi resource id for use with managed identity authentication"""
     object_id: str
+    """Object id for use with managed identity authentication"""
     sas_key: str
+    """
+    Shared access signature.
+
+    The signature is expected to be percent-encoded, `much `like they are provided in
+    the azure storage explorer or azure portal.
+    """
     sas_token: str
+    """
+    Shared access signature.
+
+    The signature is expected to be percent-encoded, `much `like they are provided in
+    the azure storage explorer or azure portal.
+    """
     skip_signature: str
+    """Skip signing requests"""
     tenant_id: str
+    """Tenant id used in oauth flows"""
     token: str
+    """Bearer token"""
     use_azure_cli: str
+    """Use azure cli for acquiring access token"""
     use_emulator: str
+    """Use object store with azurite storage emulator"""
     use_fabric_endpoint: str
+    """Use object store with url scheme account.dfs.fabric.microsoft.com"""
     ACCESS_KEY: str
+    """Master key for accessing storage account"""
     ACCOUNT_KEY: str
+    """Master key for accessing storage account"""
     ACCOUNT_NAME: str
+    """The name of the azure storage account"""
     AUTHORITY_ID: str
+    """Tenant id used in oauth flows"""
     AZURE_AUTHORITY_ID: str
+    """Tenant id used in oauth flows"""
     AZURE_CLIENT_ID: str
+    """Service principal client id for authorizing requests"""
     AZURE_CLIENT_SECRET: str
+    """Service principal client secret for authorizing requests"""
     AZURE_CONTAINER_NAME: str
+    """Container name"""
     AZURE_DISABLE_TAGGING: str
+    """Disables tagging objects"""
     AZURE_ENDPOINT: str
+    """Override the endpoint used to communicate with blob storage"""
     AZURE_FEDERATED_TOKEN_FILE: str
+    """File containing token for Azure AD workload identity federation"""
     AZURE_IDENTITY_ENDPOINT: str
+    """Endpoint to request a imds managed identity token"""
     AZURE_MSI_ENDPOINT: str
+    """Endpoint to request a imds managed identity token"""
     AZURE_MSI_RESOURCE_ID: str
+    """Msi resource id for use with managed identity authentication"""
     AZURE_OBJECT_ID: str
+    """Object id for use with managed identity authentication"""
     AZURE_SKIP_SIGNATURE: str
+    """Skip signing requests"""
     AZURE_STORAGE_ACCESS_KEY: str
+    """Master key for accessing storage account"""
     AZURE_STORAGE_ACCOUNT_KEY: str
+    """Master key for accessing storage account"""
     AZURE_STORAGE_ACCOUNT_NAME: str
+    """The name of the azure storage account"""
     AZURE_STORAGE_AUTHORITY_ID: str
+    """Tenant id used in oauth flows"""
     AZURE_STORAGE_CLIENT_ID: str
+    """Service principal client id for authorizing requests"""
     AZURE_STORAGE_CLIENT_SECRET: str
+    """Service principal client secret for authorizing requests"""
     AZURE_STORAGE_ENDPOINT: str
+    """Override the endpoint used to communicate with blob storage"""
     AZURE_STORAGE_MASTER_KEY: str
+    """Master key for accessing storage account"""
     AZURE_STORAGE_SAS_KEY: str
+    """
+    Shared access signature.
+
+    The signature is expected to be percent-encoded, `much `like they are provided in
+    the azure storage explorer or azure portal.
+    """
     AZURE_STORAGE_SAS_TOKEN: str
+    """
+    Shared access signature.
+
+    The signature is expected to be percent-encoded, `much `like they are provided in
+    the azure storage explorer or azure portal.
+    """
     AZURE_STORAGE_TENANT_ID: str
+    """Tenant id used in oauth flows"""
     AZURE_STORAGE_TOKEN: str
+    """Bearer token"""
     AZURE_STORAGE_USE_EMULATOR: str
+    """Use object store with azurite storage emulator"""
     AZURE_TENANT_ID: str
+    """Tenant id used in oauth flows"""
     AZURE_USE_AZURE_CLI: str
+    """Use azure cli for acquiring access token"""
     AZURE_USE_FABRIC_ENDPOINT: str
+    """Use object store with url scheme account.dfs.fabric.microsoft.com"""
     BEARER_TOKEN: str
+    """Bearer token"""
     CLIENT_ID: str
+    """Service principal client id for authorizing requests"""
     CLIENT_SECRET: str
+    """Service principal client secret for authorizing requests"""
     CONTAINER_NAME: str
+    """Container name"""
     DISABLE_TAGGING: str
+    """Disables tagging objects"""
     ENDPOINT: str
+    """Override the endpoint used to communicate with blob storage"""
     FEDERATED_TOKEN_FILE: str
+    """File containing token for Azure AD workload identity federation"""
     IDENTITY_ENDPOINT: str
+    """Endpoint to request a imds managed identity token"""
     MASTER_KEY: str
+    """Master key for accessing storage account"""
     MSI_ENDPOINT: str
+    """Endpoint to request a imds managed identity token"""
     MSI_RESOURCE_ID: str
+    """Msi resource id for use with managed identity authentication"""
     OBJECT_ID: str
+    """Object id for use with managed identity authentication"""
     SAS_KEY: str
+    """
+    Shared access signature.
+
+    The signature is expected to be percent-encoded, `much `like they are provided in
+    the azure storage explorer or azure portal.
+    """
     SAS_TOKEN: str
+    """
+    Shared access signature.
+
+    The signature is expected to be percent-encoded, `much `like they are provided in
+    the azure storage explorer or azure portal.
+    """
     SKIP_SIGNATURE: str
+    """Skip signing requests"""
     TENANT_ID: str
+    """Tenant id used in oauth flows"""
     TOKEN: str
+    """Bearer token"""
     USE_AZURE_CLI: str
+    """Use azure cli for acquiring access token"""
     USE_EMULATOR: str
+    """Use object store with azurite storage emulator"""
     USE_FABRIC_ENDPOINT: str
-
-"""Valid Azure storage configuration keys
-
-Either lower case or upper case strings are accepted.
-
-- `"azure_storage_account_key"`, `"azure_storage_access_key"`, `"azure_storage_master_key"`, `"master_key"`, `"account_key"`, `"access_key"`: Master key for accessing storage account
-- `"azure_storage_account_name"`, `"account_name"`: The name of the azure storage account
-- `"azure_storage_client_id"`, `"azure_client_id"`, `"client_id"`: Service principal client id for authorizing requests
-- `"azure_storage_client_secret"`, `"azure_client_secret"`, `"client_secret"`: Service principal client secret for authorizing requests
-- `"azure_storage_tenant_id"`, `"azure_storage_authority_id"`, `"azure_tenant_id"`, `"azure_authority_id"`, `"tenant_id"`, `"authority_id"`: Tenant id used in oauth flows
-- `"azure_storage_sas_key"`, `"azure_storage_sas_token"`, `"sas_key"`, `"sas_token"`: Shared access signature.
-
-    The signature is expected to be percent-encoded, `much `like they are provided in the azure storage explorer or azure portal.
-
-- `"azure_storage_token"`, `"bearer_token"`, `"token"`: Bearer token
-- `"azure_storage_use_emulator"`, `"use_emulator"`: Use object store with azurite storage emulator
-- `"azure_storage_endpoint"`, `"azure_endpoint"`, `"endpoint"`: Override the endpoint used to communicate with blob storage
-- `"azure_msi_endpoint"`, `"azure_identity_endpoint"`, `"identity_endpoint"`, `"msi_endpoint"`: Endpoint to request a imds managed identity token
-- `"azure_object_id"`, `"object_id"`: Object id for use with managed identity authentication
-- `"azure_msi_resource_id"`, `"msi_resource_id"`: Msi resource id for use with managed identity authentication
-- `"azure_federated_token_file"`, `"federated_token_file"`: File containing token for Azure AD workload identity federation
-- `"azure_use_fabric_endpoint"`, `"use_fabric_endpoint"`: Use object store with url scheme account.dfs.fabric.microsoft.com
-- `"azure_use_azure_cli"`, `"use_azure_cli"`: Use azure cli for acquiring access token
-- `"azure_skip_signature"`, `"skip_signature"`: Skip signing requests
-- `"azure_container_name"`, `"container_name"`: Container name
-- `"azure_disable_tagging"`, `"disable_tagging"`: Disables tagging objects
-"""
+    """Use object store with url scheme account.dfs.fabric.microsoft.com"""
 
 class AzureStore:
     """Configure a connection to Microsoft Azure Blob Storage container using the specified credentials."""

--- a/obstore/python/obstore/store/_azure.pyi
+++ b/obstore/python/obstore/store/_azure.pyi
@@ -26,7 +26,7 @@ class AzureConfig(TypedDict, total=False):
     """Service principal client secret for authorizing requests"""
     azure_container_name: str
     """Container name"""
-    azure_disable_tagging: str
+    azure_disable_tagging: bool
     """Disables tagging objects"""
     azure_endpoint: str
     """Override the endpoint used to communicate with blob storage"""
@@ -40,7 +40,7 @@ class AzureConfig(TypedDict, total=False):
     """Msi resource id for use with managed identity authentication"""
     azure_object_id: str
     """Object id for use with managed identity authentication"""
-    azure_skip_signature: str
+    azure_skip_signature: bool
     """Skip signing requests"""
     azure_storage_access_key: str
     """Master key for accessing storage account"""
@@ -76,13 +76,13 @@ class AzureConfig(TypedDict, total=False):
     """Tenant id used in oauth flows"""
     azure_storage_token: str
     """Bearer token"""
-    azure_storage_use_emulator: str
+    azure_storage_use_emulator: bool
     """Use object store with azurite storage emulator"""
     azure_tenant_id: str
     """Tenant id used in oauth flows"""
-    azure_use_azure_cli: str
+    azure_use_azure_cli: bool
     """Use azure cli for acquiring access token"""
-    azure_use_fabric_endpoint: str
+    azure_use_fabric_endpoint: bool
     """Use object store with url scheme account.dfs.fabric.microsoft.com"""
     bearer_token: str
     """Bearer token"""
@@ -92,7 +92,7 @@ class AzureConfig(TypedDict, total=False):
     """Service principal client secret for authorizing requests"""
     container_name: str
     """Container name"""
-    disable_tagging: str
+    disable_tagging: bool
     """Disables tagging objects"""
     endpoint: str
     """Override the endpoint used to communicate with blob storage"""
@@ -122,17 +122,17 @@ class AzureConfig(TypedDict, total=False):
     The signature is expected to be percent-encoded, `much `like they are provided in
     the azure storage explorer or azure portal.
     """
-    skip_signature: str
+    skip_signature: bool
     """Skip signing requests"""
     tenant_id: str
     """Tenant id used in oauth flows"""
     token: str
     """Bearer token"""
-    use_azure_cli: str
+    use_azure_cli: bool
     """Use azure cli for acquiring access token"""
-    use_emulator: str
+    use_emulator: bool
     """Use object store with azurite storage emulator"""
-    use_fabric_endpoint: str
+    use_fabric_endpoint: bool
     """Use object store with url scheme account.dfs.fabric.microsoft.com"""
     ACCESS_KEY: str
     """Master key for accessing storage account"""
@@ -150,7 +150,7 @@ class AzureConfig(TypedDict, total=False):
     """Service principal client secret for authorizing requests"""
     AZURE_CONTAINER_NAME: str
     """Container name"""
-    AZURE_DISABLE_TAGGING: str
+    AZURE_DISABLE_TAGGING: bool
     """Disables tagging objects"""
     AZURE_ENDPOINT: str
     """Override the endpoint used to communicate with blob storage"""
@@ -164,7 +164,7 @@ class AzureConfig(TypedDict, total=False):
     """Msi resource id for use with managed identity authentication"""
     AZURE_OBJECT_ID: str
     """Object id for use with managed identity authentication"""
-    AZURE_SKIP_SIGNATURE: str
+    AZURE_SKIP_SIGNATURE: bool
     """Skip signing requests"""
     AZURE_STORAGE_ACCESS_KEY: str
     """Master key for accessing storage account"""
@@ -200,13 +200,13 @@ class AzureConfig(TypedDict, total=False):
     """Tenant id used in oauth flows"""
     AZURE_STORAGE_TOKEN: str
     """Bearer token"""
-    AZURE_STORAGE_USE_EMULATOR: str
+    AZURE_STORAGE_USE_EMULATOR: bool
     """Use object store with azurite storage emulator"""
     AZURE_TENANT_ID: str
     """Tenant id used in oauth flows"""
-    AZURE_USE_AZURE_CLI: str
+    AZURE_USE_AZURE_CLI: bool
     """Use azure cli for acquiring access token"""
-    AZURE_USE_FABRIC_ENDPOINT: str
+    AZURE_USE_FABRIC_ENDPOINT: bool
     """Use object store with url scheme account.dfs.fabric.microsoft.com"""
     BEARER_TOKEN: str
     """Bearer token"""
@@ -216,7 +216,7 @@ class AzureConfig(TypedDict, total=False):
     """Service principal client secret for authorizing requests"""
     CONTAINER_NAME: str
     """Container name"""
-    DISABLE_TAGGING: str
+    DISABLE_TAGGING: bool
     """Disables tagging objects"""
     ENDPOINT: str
     """Override the endpoint used to communicate with blob storage"""
@@ -246,17 +246,17 @@ class AzureConfig(TypedDict, total=False):
     The signature is expected to be percent-encoded, `much `like they are provided in
     the azure storage explorer or azure portal.
     """
-    SKIP_SIGNATURE: str
+    SKIP_SIGNATURE: bool
     """Skip signing requests"""
     TENANT_ID: str
     """Tenant id used in oauth flows"""
     TOKEN: str
     """Bearer token"""
-    USE_AZURE_CLI: str
+    USE_AZURE_CLI: bool
     """Use azure cli for acquiring access token"""
-    USE_EMULATOR: str
+    USE_EMULATOR: bool
     """Use object store with azurite storage emulator"""
-    USE_FABRIC_ENDPOINT: str
+    USE_FABRIC_ENDPOINT: bool
     """Use object store with url scheme account.dfs.fabric.microsoft.com"""
 
 class AzureStore:

--- a/obstore/python/obstore/store/_client.pyi
+++ b/obstore/python/obstore/store/_client.pyi
@@ -1,41 +1,12 @@
-from typing import Literal
+from typing import TypedDict
 
-ClientConfigKey = Literal[
-    "allow_http",
-    "allow_invalid_certificates",
-    "connect_timeout",
-    "default_content_type",
-    "http1_only",
-    "http2_keep_alive_interval",
-    "http2_keep_alive_timeout",
-    "http2_keep_alive_while_idle",
-    "http2_only",
-    "pool_idle_timeout",
-    "pool_max_idle_per_host",
-    "proxy_url",
-    "timeout",
-    "user_agent",
-    "ALLOW_HTTP",
-    "ALLOW_INVALID_CERTIFICATES",
-    "CONNECT_TIMEOUT",
-    "DEFAULT_CONTENT_TYPE",
-    "HTTP1_ONLY",
-    "HTTP2_KEEP_ALIVE_INTERVAL",
-    "HTTP2_KEEP_ALIVE_TIMEOUT",
-    "HTTP2_KEEP_ALIVE_WHILE_IDLE",
-    "HTTP2_ONLY",
-    "POOL_IDLE_TIMEOUT",
-    "POOL_MAX_IDLE_PER_HOST",
-    "PROXY_URL",
-    "TIMEOUT",
-    "USER_AGENT",
-]
-"""Allowed client configuration keys
+class ClientConfig(TypedDict, total=False):
+    """HTTP client configuration"""
 
-Either lower case or upper case strings are accepted.
-
-- `"allow_http"`: Allow non-TLS, i.e. non-HTTPS connections.
-- `"allow_invalid_certificates"`: Skip certificate validation on https connections.
+    allow_http: bool
+    """Allow non-TLS, i.e. non-HTTPS connections."""
+    allow_invalid_certificates: bool
+    """Skip certificate validation on https connections.
 
     !!! warning
 
@@ -44,20 +15,35 @@ Either lower case or upper case strings are accepted.
         will be trusted for use. This includes expired certificates. This
         introduces significant vulnerabilities, and should only be used
         as a last resort or for testing
+    """
+    connect_timeout: str
+    """Timeout for only the connect phase of a Client"""
+    default_content_type: str
+    """default `CONTENT_TYPE` for uploads"""
+    http1_only: bool
+    """Only use http1 connections."""
+    http2_keep_alive_interval: str
+    """Interval for HTTP2 Ping frames should be sent to keep a connection alive."""
+    http2_keep_alive_timeout: str
+    """Timeout for receiving an acknowledgement of the keep-alive ping."""
+    http2_keep_alive_while_idle: str
+    """Enable HTTP2 keep alive pings for idle connections"""
+    http2_only: bool
+    """Only use http2 connections"""
+    pool_idle_timeout: str
+    """The pool max idle timeout.
 
-- `"connect_timeout"`: Timeout for only the connect phase of a Client
-- `"default_content_type"`: default `CONTENT_TYPE` for uploads
-- `"http1_only"`: Only use http1 connections.
-- `"http2_keep_alive_interval"`: Interval for HTTP2 Ping frames should be sent to keep a connection alive.
-- `"http2_keep_alive_timeout"`: Timeout for receiving an acknowledgement of the keep-alive ping.
-- `"http2_keep_alive_while_idle"`: Enable HTTP2 keep alive pings for idle connections
-- `"http2_only"`: Only use http2 connections
-- `"pool_idle_timeout"`: The pool max idle timeout.
     This is the length of time an idle connection will be kept alive.
-- `"pool_max_idle_per_host"`: maximum number of idle connections per host.
-- `"proxy_url"`: HTTP proxy to use for requests.
-- `"timeout"`: Request timeout.
+    """
+    pool_max_idle_per_host: str
+    """Maximum number of idle connections per host."""
+    proxy_url: str
+    """HTTP proxy to use for requests."""
+    timeout: str
+    """Request timeout.
+
     The timeout is applied from when the request starts connecting until the
     response body has finished.
-- `"user_agent"`: User-Agent header to be used by this client.
-"""
+    """
+    user_agent: str
+    """User-Agent header to be used by this client."""

--- a/obstore/python/obstore/store/_gcs.pyi
+++ b/obstore/python/obstore/store/_gcs.pyi
@@ -1,32 +1,33 @@
-from typing import Dict, Literal
+from typing import Dict, TypedDict, Unpack
 
 from ._client import ClientConfigKey
 from ._retry import RetryConfig
 
-GCSConfigKey = Literal[
-    "bucket_name",
-    "bucket",
-    "google_application_credentials",
-    "google_bucket_name",
-    "google_bucket",
-    "google_service_account_key",
-    "google_service_account_path",
-    "google_service_account",
-    "service_account_key",
-    "service_account_path",
-    "service_account",
-    "BUCKET_NAME",
-    "BUCKET",
-    "GOOGLE_APPLICATION_CREDENTIALS",
-    "GOOGLE_BUCKET_NAME",
-    "GOOGLE_BUCKET",
-    "GOOGLE_SERVICE_ACCOUNT_KEY",
-    "GOOGLE_SERVICE_ACCOUNT_PATH",
-    "GOOGLE_SERVICE_ACCOUNT",
-    "SERVICE_ACCOUNT_KEY",
-    "SERVICE_ACCOUNT_PATH",
-    "SERVICE_ACCOUNT",
-]
+# Note: we removed `bucket` because it overlaps with an existing named arg in the
+# constructors
+class GCSConfig(TypedDict, total=False):
+    bucket_name: str
+    google_application_credentials: str
+    google_bucket_name: str
+    google_bucket: str
+    google_service_account_key: str
+    google_service_account_path: str
+    google_service_account: str
+    service_account_key: str
+    service_account_path: str
+    service_account: str
+    BUCKET_NAME: str
+    BUCKET: str
+    GOOGLE_APPLICATION_CREDENTIALS: str
+    GOOGLE_BUCKET_NAME: str
+    GOOGLE_BUCKET: str
+    GOOGLE_SERVICE_ACCOUNT_KEY: str
+    GOOGLE_SERVICE_ACCOUNT_PATH: str
+    GOOGLE_SERVICE_ACCOUNT: str
+    SERVICE_ACCOUNT_KEY: str
+    SERVICE_ACCOUNT_PATH: str
+    SERVICE_ACCOUNT: str
+
 """Valid Google Cloud Storage configuration keys
 
 Either lower case or upper case strings are accepted.
@@ -49,9 +50,10 @@ class GCSStore:
         self,
         bucket: str,
         *,
-        config: Dict[GCSConfigKey, str] | None = None,
+        config: GCSConfig | None = None,
         client_options: Dict[ClientConfigKey, str | bool] | None = None,
         retry_config: RetryConfig | None = None,
+        **kwargs: Unpack[GCSConfig],
     ) -> None:
         """Construct a new GCSStore.
 
@@ -72,9 +74,10 @@ class GCSStore:
         cls,
         bucket: str,
         *,
-        config: Dict[GCSConfigKey, str] | None = None,
+        config: GCSConfig | None = None,
         client_options: Dict[ClientConfigKey, str | bool] | None = None,
         retry_config: RetryConfig | None = None,
+        **kwargs: Unpack[GCSConfig],
     ) -> GCSStore:
         """Construct a new GCSStore with values pre-populated from environment variables.
 
@@ -104,9 +107,10 @@ class GCSStore:
         cls,
         url: str,
         *,
-        config: Dict[GCSConfigKey, str] | None = None,
+        config: GCSConfig | None = None,
         client_options: Dict[ClientConfigKey, str | bool] | None = None,
         retry_config: RetryConfig | None = None,
+        **kwargs: Unpack[GCSConfig],
     ) -> GCSStore:
         """Construct a new GCSStore with values populated from a well-known storage URL.
 

--- a/obstore/python/obstore/store/_gcs.pyi
+++ b/obstore/python/obstore/store/_gcs.pyi
@@ -6,37 +6,58 @@ from ._retry import RetryConfig
 # Note: we removed `bucket` because it overlaps with an existing named arg in the
 # constructors
 class GCSConfig(TypedDict, total=False):
+    """Configuration parameters for GCSStore.
+
+    There are duplicates of many parameters, and parameters can be either upper or lower
+    case. Not all parameters are required.
+    """
+
     bucket_name: str
+    """Bucket name."""
     google_application_credentials: str
+    """Application credentials path.
+
+    See <https://cloud.google.com/docs/authentication/provide-credentials-adc>."""
     google_bucket_name: str
+    """Bucket name."""
     google_bucket: str
+    """Bucket name."""
     google_service_account_key: str
+    """The serialized service account key"""
     google_service_account_path: str
+    """Path to the service account file."""
     google_service_account: str
+    """Path to the service account file."""
     service_account_key: str
+    """The serialized service account key"""
     service_account_path: str
+    """Path to the service account file."""
     service_account: str
+    """Path to the service account file."""
     BUCKET_NAME: str
+    """Bucket name."""
     BUCKET: str
+    """Bucket name."""
     GOOGLE_APPLICATION_CREDENTIALS: str
+    """Application credentials path.
+
+    See <https://cloud.google.com/docs/authentication/provide-credentials-adc>."""
     GOOGLE_BUCKET_NAME: str
+    """Bucket name."""
     GOOGLE_BUCKET: str
+    """Bucket name."""
     GOOGLE_SERVICE_ACCOUNT_KEY: str
+    """The serialized service account key"""
     GOOGLE_SERVICE_ACCOUNT_PATH: str
+    """Path to the service account file."""
     GOOGLE_SERVICE_ACCOUNT: str
+    """Path to the service account file."""
     SERVICE_ACCOUNT_KEY: str
+    """The serialized service account key"""
     SERVICE_ACCOUNT_PATH: str
+    """Path to the service account file."""
     SERVICE_ACCOUNT: str
-
-"""Valid Google Cloud Storage configuration keys
-
-Either lower case or upper case strings are accepted.
-
-- `"google_service_account"` or `"service_account"` or `"google_service_account_path"` or "service_account_path":  Path to the service account file.
-- `"google_service_account_key"` or `"service_account_key"`: The serialized service account key
-- `"google_bucket"` or `"google_bucket_name"` or `"bucket"` or `"bucket_name"`: Bucket name.
-- `"google_application_credentials"`: Application credentials path. See <https://cloud.google.com/docs/authentication/provide-credentials-adc>.
-"""
+    """Path to the service account file."""
 
 class GCSStore:
     """Configure a connection to Google Cloud Storage.

--- a/obstore/python/obstore/store/_gcs.pyi
+++ b/obstore/python/obstore/store/_gcs.pyi
@@ -1,6 +1,6 @@
-from typing import Dict, TypedDict, Unpack
+from typing import TypedDict, Unpack
 
-from ._client import ClientConfigKey
+from ._client import ClientConfig
 from ._retry import RetryConfig
 
 # Note: we removed `bucket` because it overlaps with an existing named arg in the
@@ -72,7 +72,7 @@ class GCSStore:
         bucket: str,
         *,
         config: GCSConfig | None = None,
-        client_options: Dict[ClientConfigKey, str | bool] | None = None,
+        client_options: ClientConfig | None = None,
         retry_config: RetryConfig | None = None,
         **kwargs: Unpack[GCSConfig],
     ) -> None:
@@ -96,7 +96,7 @@ class GCSStore:
         bucket: str,
         *,
         config: GCSConfig | None = None,
-        client_options: Dict[ClientConfigKey, str | bool] | None = None,
+        client_options: ClientConfig | None = None,
         retry_config: RetryConfig | None = None,
         **kwargs: Unpack[GCSConfig],
     ) -> GCSStore:
@@ -129,7 +129,7 @@ class GCSStore:
         url: str,
         *,
         config: GCSConfig | None = None,
-        client_options: Dict[ClientConfigKey, str | bool] | None = None,
+        client_options: ClientConfig | None = None,
         retry_config: RetryConfig | None = None,
         **kwargs: Unpack[GCSConfig],
     ) -> GCSStore:

--- a/obstore/python/obstore/store/_http.pyi
+++ b/obstore/python/obstore/store/_http.pyi
@@ -1,6 +1,4 @@
-from typing import Dict
-
-from ._client import ClientConfigKey
+from ._client import ClientConfig
 from ._retry import RetryConfig
 
 class HTTPStore:
@@ -28,7 +26,7 @@ class HTTPStore:
         cls,
         url: str,
         *,
-        client_options: Dict[ClientConfigKey, str | bool] | None = None,
+        client_options: ClientConfig | None = None,
         retry_config: RetryConfig | None = None,
     ) -> HTTPStore:
         """Construct a new HTTPStore from a URL

--- a/pyo3-bytes/bytes.pyi
+++ b/pyo3-bytes/bytes.pyi
@@ -11,7 +11,9 @@ class Bytes(Buffer):
     to underlying Rust memory.
 
     You can pass this to `memoryview` for a zero-copy view into the underlying
-    data.
+    data or to `bytes` to copy the underlying data into a Python `bytes`.
+
+    Many methods from the Python `bytes` class are implemented on this,
     """
 
     def __add__(self, other: Buffer) -> Bytes: ...
@@ -33,46 +35,53 @@ class Bytes(Buffer):
         """
     def isalnum(self) -> bool:
         """
-        Return True if all bytes in the sequence are alphabetical ASCII characters or
-        ASCII decimal digits and the sequence is not empty, False otherwise. Alphabetic
-        ASCII characters are those byte values in the sequence
-        b'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'. ASCII decimal digits
-        are those byte values in the sequence b'0123456789'.
+        Return `True` if all bytes in the sequence are alphabetical ASCII characters or
+        ASCII decimal digits and the sequence is not empty, `False` otherwise.
+
+        Alphabetic ASCII characters are those byte values in the sequence
+        `b'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'`. ASCII decimal digits
+        are those byte values in the sequence `b'0123456789'`.
         """
     def isalpha(self) -> bool:
         """
-        Return True if all bytes in the sequence are alphabetic ASCII characters and the
-        sequence is not empty, False otherwise. Alphabetic ASCII characters are those
-        byte values in the sequence
-        b'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'.
+        Return `True` if all bytes in the sequence are alphabetic ASCII characters and
+        the sequence is not empty, `False` otherwise.
+
+        Alphabetic ASCII characters are those byte values in the sequence
+        `b'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'`.
         """
     def isascii(self) -> bool:
         """
-        Return True if the sequence is empty or all bytes in the sequence are ASCII,
-        False otherwise. ASCII bytes are in the range 0-0x7F.
+        Return `True` if the sequence is empty or all bytes in the sequence are ASCII,
+        `False` otherwise.
+
+        ASCII bytes are in the range `0-0x7F`.
         """
     def isdigit(self) -> bool:
         """
-        Return True if all bytes in the sequence are ASCII decimal digits and the
-        sequence is not empty, False otherwise. ASCII decimal digits are those byte
-        values in the sequence b'0123456789'.
+        Return `True` if all bytes in the sequence are ASCII decimal digits and the
+        sequence is not empty, `False` otherwise.
+
+        ASCII decimal digits are those byte values in the sequence `b'0123456789'`.
         """
     def islower(self) -> bool:
         """
-        Return True if there is at least one lowercase ASCII character in the sequence
-        and no uppercase ASCII characters, False otherwise.
+        Return `True` if there is at least one lowercase ASCII character in the sequence
+        and no uppercase ASCII characters, `False` otherwise.
         """
     def isspace(self) -> bool:
         """
-        Return True if all bytes in the sequence are ASCII whitespace and the sequence
-        is not empty, False otherwise. ASCII whitespace characters are those byte values
-        in the sequence b' \t\n\r\x0b\f' (space, tab, newline, carriage return, vertical
-        tab, form feed).
+        Return `True` if all bytes in the sequence are ASCII whitespace and the sequence
+        is not empty, `False` otherwise.
+
+        ASCII whitespace characters are those byte values
+        in the sequence `b' \t\n\r\x0b\f'` (space, tab, newline, carriage return,
+        vertical tab, form feed).
         """
     def isupper(self) -> bool:
         """
-        Return True if there is at least one uppercase alphabetic ASCII character in the
-        sequence and no lowercase ASCII characters, False otherwise.
+        Return `True` if there is at least one uppercase alphabetic ASCII character in
+        the sequence and no lowercase ASCII characters, `False` otherwise.
         """
 
     def lower(self) -> Bytes:

--- a/pyo3-object_store/src/aws.rs
+++ b/pyo3-object_store/src/aws.rs
@@ -57,36 +57,6 @@ impl PyS3Store {
         Ok(Self(Arc::new(builder.build()?)))
     }
 
-    // Helper to create anonymous connections
-    #[classmethod]
-    #[pyo3(signature = (bucket, *, config=None, client_options=None, retry_config=None, **kwargs))]
-    fn anon(
-        _cls: &Bound<PyType>,
-        bucket: String,
-        config: Option<PyAmazonS3Config>,
-        client_options: Option<PyClientOptions>,
-        retry_config: Option<PyRetryConfig>,
-        kwargs: Option<PyAmazonS3Config>,
-    ) -> PyObjectStoreResult<Self> {
-        let mut builder = AmazonS3Builder::new()
-            .with_bucket_name(bucket)
-            .with_skip_signature(true);
-
-        if let Some(config) = config {
-            builder = config.apply_config(builder);
-        }
-        if let Some(kwargs) = kwargs {
-            builder = kwargs.apply_config(builder);
-        }
-        if let Some(client_options) = client_options {
-            builder = builder.with_client_options(client_options.into())
-        }
-        if let Some(retry_config) = retry_config {
-            builder = builder.with_retry(retry_config.into())
-        }
-        Ok(Self(Arc::new(builder.build()?)))
-    }
-
     // Create from env variables
     #[classmethod]
     #[pyo3(signature = (bucket=None, *, config=None, client_options=None, retry_config=None, **kwargs))]

--- a/pyo3-object_store/src/aws.rs
+++ b/pyo3-object_store/src/aws.rs
@@ -9,6 +9,7 @@ use pyo3::pybacked::PyBackedStr;
 use pyo3::types::PyType;
 
 use crate::client::PyClientOptions;
+use crate::config::PyConfigValue;
 use crate::error::{PyObjectStoreError, PyObjectStoreResult};
 use crate::retry::PyRetryConfig;
 
@@ -194,7 +195,7 @@ impl<'py> FromPyObject<'py> for PyAmazonS3ConfigKey {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct PyAmazonS3Config(HashMap<PyAmazonS3ConfigKey, String>);
+pub struct PyAmazonS3Config(HashMap<PyAmazonS3ConfigKey, PyConfigValue>);
 
 impl<'py> FromPyObject<'py> for PyAmazonS3Config {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
@@ -205,7 +206,7 @@ impl<'py> FromPyObject<'py> for PyAmazonS3Config {
 impl PyAmazonS3Config {
     fn apply_config(self, mut builder: AmazonS3Builder) -> AmazonS3Builder {
         for (key, value) in self.0.into_iter() {
-            builder = builder.with_config(key.0, value);
+            builder = builder.with_config(key.0, value.0);
         }
         builder
     }

--- a/pyo3-object_store/src/azure.rs
+++ b/pyo3-object_store/src/azure.rs
@@ -8,6 +8,7 @@ use pyo3::pybacked::PyBackedStr;
 use pyo3::types::PyType;
 
 use crate::client::PyClientOptions;
+use crate::config::PyConfigValue;
 use crate::error::{PyObjectStoreError, PyObjectStoreResult};
 use crate::retry::PyRetryConfig;
 
@@ -127,7 +128,7 @@ impl<'py> FromPyObject<'py> for PyAzureConfigKey {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct PyAzureConfig(HashMap<PyAzureConfigKey, String>);
+pub struct PyAzureConfig(HashMap<PyAzureConfigKey, PyConfigValue>);
 
 impl<'py> FromPyObject<'py> for PyAzureConfig {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
@@ -138,7 +139,7 @@ impl<'py> FromPyObject<'py> for PyAzureConfig {
 impl PyAzureConfig {
     fn apply_config(self, mut builder: MicrosoftAzureBuilder) -> MicrosoftAzureBuilder {
         for (key, value) in self.0.into_iter() {
-            builder = builder.with_config(key.0, value);
+            builder = builder.with_config(key.0, value.0);
         }
         builder
     }

--- a/pyo3-object_store/src/azure.rs
+++ b/pyo3-object_store/src/azure.rs
@@ -32,18 +32,20 @@ impl PyAzureStore {
 impl PyAzureStore {
     // Create from parameters
     #[new]
-    #[pyo3(signature = (container, *, config=None, client_options=None, retry_config=None))]
+    #[pyo3(signature = (container, *, config=None, client_options=None, retry_config=None, **kwargs))]
     fn new(
         container: String,
-        config: Option<HashMap<PyAzureConfigKey, String>>,
+        config: Option<PyAzureConfig>,
         client_options: Option<PyClientOptions>,
         retry_config: Option<PyRetryConfig>,
+        kwargs: Option<PyAzureConfig>,
     ) -> PyObjectStoreResult<Self> {
         let mut builder = MicrosoftAzureBuilder::new().with_container_name(container);
         if let Some(config) = config {
-            for (key, value) in config.into_iter() {
-                builder = builder.with_config(key.0, value);
-            }
+            builder = config.apply_config(builder);
+        }
+        if let Some(kwargs) = kwargs {
+            builder = kwargs.apply_config(builder);
         }
         if let Some(client_options) = client_options {
             builder = builder.with_client_options(client_options.into())
@@ -56,19 +58,21 @@ impl PyAzureStore {
 
     // Create from env variables
     #[classmethod]
-    #[pyo3(signature = (container, *, config=None, client_options=None, retry_config=None))]
+    #[pyo3(signature = (container, *, config=None, client_options=None, retry_config=None, **kwargs))]
     fn from_env(
         _cls: &Bound<PyType>,
         container: String,
-        config: Option<HashMap<PyAzureConfigKey, String>>,
+        config: Option<PyAzureConfig>,
         client_options: Option<PyClientOptions>,
         retry_config: Option<PyRetryConfig>,
+        kwargs: Option<PyAzureConfig>,
     ) -> PyObjectStoreResult<Self> {
         let mut builder = MicrosoftAzureBuilder::from_env().with_container_name(container);
         if let Some(config) = config {
-            for (key, value) in config.into_iter() {
-                builder = builder.with_config(key.0, value);
-            }
+            builder = config.apply_config(builder);
+        }
+        if let Some(kwargs) = kwargs {
+            builder = kwargs.apply_config(builder);
         }
         if let Some(client_options) = client_options {
             builder = builder.with_client_options(client_options.into())
@@ -80,19 +84,21 @@ impl PyAzureStore {
     }
 
     #[classmethod]
-    #[pyo3(signature = (url, *, config=None, client_options=None, retry_config=None))]
+    #[pyo3(signature = (url, *, config=None, client_options=None, retry_config=None, **kwargs))]
     fn from_url(
         _cls: &Bound<PyType>,
         url: &str,
-        config: Option<HashMap<PyAzureConfigKey, String>>,
+        config: Option<PyAzureConfig>,
         client_options: Option<PyClientOptions>,
         retry_config: Option<PyRetryConfig>,
+        kwargs: Option<PyAzureConfig>,
     ) -> PyObjectStoreResult<Self> {
         let mut builder = MicrosoftAzureBuilder::from_env().with_url(url);
         if let Some(config) = config {
-            for (key, value) in config.into_iter() {
-                builder = builder.with_config(key.0, value);
-            }
+            builder = config.apply_config(builder);
+        }
+        if let Some(kwargs) = kwargs {
+            builder = kwargs.apply_config(builder);
         }
         if let Some(client_options) = client_options {
             builder = builder.with_client_options(client_options.into())
@@ -117,5 +123,23 @@ impl<'py> FromPyObject<'py> for PyAzureConfigKey {
         let s = ob.extract::<PyBackedStr>()?.to_lowercase();
         let key = AzureConfigKey::from_str(&s).map_err(PyObjectStoreError::ObjectStoreError)?;
         Ok(Self(key))
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct PyAzureConfig(HashMap<PyAzureConfigKey, String>);
+
+impl<'py> FromPyObject<'py> for PyAzureConfig {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+        Ok(Self(ob.extract()?))
+    }
+}
+
+impl PyAzureConfig {
+    fn apply_config(self, mut builder: MicrosoftAzureBuilder) -> MicrosoftAzureBuilder {
+        for (key, value) in self.0.into_iter() {
+            builder = builder.with_config(key.0, value);
+        }
+        builder
     }
 }

--- a/pyo3-object_store/src/config.rs
+++ b/pyo3-object_store/src/config.rs
@@ -1,0 +1,20 @@
+use pyo3::prelude::*;
+
+/// A wrapper around `String` used to store values for config values.
+///
+/// Supported Python input:
+///
+/// - str
+/// - `True` and `False` (becomes `"true"` and `"false"`)
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct PyConfigValue(pub String);
+
+impl<'py> FromPyObject<'py> for PyConfigValue {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+        if let Ok(val) = ob.extract::<bool>() {
+            Ok(Self(val.to_string()))
+        } else {
+            Ok(Self(ob.extract()?))
+        }
+    }
+}

--- a/pyo3-object_store/src/gcp.rs
+++ b/pyo3-object_store/src/gcp.rs
@@ -32,18 +32,20 @@ impl PyGCSStore {
 impl PyGCSStore {
     // Create from parameters
     #[new]
-    #[pyo3(signature = (bucket, *, config=None, client_options=None, retry_config=None))]
+    #[pyo3(signature = (bucket, *, config=None, client_options=None, retry_config=None, **kwargs))]
     fn new(
         bucket: String,
-        config: Option<HashMap<PyGoogleConfigKey, String>>,
+        config: Option<PyGoogleConfig>,
         client_options: Option<PyClientOptions>,
         retry_config: Option<PyRetryConfig>,
+        kwargs: Option<PyGoogleConfig>,
     ) -> PyObjectStoreResult<Self> {
         let mut builder = GoogleCloudStorageBuilder::new().with_bucket_name(bucket);
         if let Some(config) = config {
-            for (key, value) in config.into_iter() {
-                builder = builder.with_config(key.0, value);
-            }
+            builder = config.apply_config(builder);
+        }
+        if let Some(kwargs) = kwargs {
+            builder = kwargs.apply_config(builder);
         }
         if let Some(client_options) = client_options {
             builder = builder.with_client_options(client_options.into())
@@ -56,19 +58,21 @@ impl PyGCSStore {
 
     // Create from env variables
     #[classmethod]
-    #[pyo3(signature = (bucket, *, config=None, client_options=None, retry_config=None))]
+    #[pyo3(signature = (bucket, *, config=None, client_options=None, retry_config=None, **kwargs))]
     fn from_env(
         _cls: &Bound<PyType>,
         bucket: String,
-        config: Option<HashMap<PyGoogleConfigKey, String>>,
+        config: Option<PyGoogleConfig>,
         client_options: Option<PyClientOptions>,
         retry_config: Option<PyRetryConfig>,
+        kwargs: Option<PyGoogleConfig>,
     ) -> PyObjectStoreResult<Self> {
         let mut builder = GoogleCloudStorageBuilder::from_env().with_bucket_name(bucket);
         if let Some(config) = config {
-            for (key, value) in config.into_iter() {
-                builder = builder.with_config(key.0, value);
-            }
+            builder = config.apply_config(builder);
+        }
+        if let Some(kwargs) = kwargs {
+            builder = kwargs.apply_config(builder);
         }
         if let Some(client_options) = client_options {
             builder = builder.with_client_options(client_options.into())
@@ -80,19 +84,21 @@ impl PyGCSStore {
     }
 
     #[classmethod]
-    #[pyo3(signature = (url, *, config=None, client_options=None, retry_config=None))]
+    #[pyo3(signature = (url, *, config=None, client_options=None, retry_config=None, **kwargs))]
     fn from_url(
         _cls: &Bound<PyType>,
         url: &str,
-        config: Option<HashMap<PyGoogleConfigKey, String>>,
+        config: Option<PyGoogleConfig>,
         client_options: Option<PyClientOptions>,
         retry_config: Option<PyRetryConfig>,
+        kwargs: Option<PyGoogleConfig>,
     ) -> PyObjectStoreResult<Self> {
         let mut builder = GoogleCloudStorageBuilder::from_env().with_url(url);
         if let Some(config) = config {
-            for (key, value) in config.into_iter() {
-                builder = builder.with_config(key.0, value);
-            }
+            builder = config.apply_config(builder);
+        }
+        if let Some(kwargs) = kwargs {
+            builder = kwargs.apply_config(builder);
         }
         if let Some(client_options) = client_options {
             builder = builder.with_client_options(client_options.into())
@@ -117,5 +123,23 @@ impl<'py> FromPyObject<'py> for PyGoogleConfigKey {
         let s = ob.extract::<PyBackedStr>()?.to_lowercase();
         let key = GoogleConfigKey::from_str(&s).map_err(PyObjectStoreError::ObjectStoreError)?;
         Ok(Self(key))
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct PyGoogleConfig(HashMap<PyGoogleConfigKey, String>);
+
+impl<'py> FromPyObject<'py> for PyGoogleConfig {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+        Ok(Self(ob.extract()?))
+    }
+}
+
+impl PyGoogleConfig {
+    fn apply_config(self, mut builder: GoogleCloudStorageBuilder) -> GoogleCloudStorageBuilder {
+        for (key, value) in self.0.into_iter() {
+            builder = builder.with_config(key.0, value);
+        }
+        builder
     }
 }

--- a/pyo3-object_store/src/gcp.rs
+++ b/pyo3-object_store/src/gcp.rs
@@ -8,6 +8,7 @@ use pyo3::pybacked::PyBackedStr;
 use pyo3::types::PyType;
 
 use crate::client::PyClientOptions;
+use crate::config::PyConfigValue;
 use crate::error::{PyObjectStoreError, PyObjectStoreResult};
 use crate::retry::PyRetryConfig;
 
@@ -127,7 +128,7 @@ impl<'py> FromPyObject<'py> for PyGoogleConfigKey {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct PyGoogleConfig(HashMap<PyGoogleConfigKey, String>);
+pub struct PyGoogleConfig(HashMap<PyGoogleConfigKey, PyConfigValue>);
 
 impl<'py> FromPyObject<'py> for PyGoogleConfig {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
@@ -138,7 +139,7 @@ impl<'py> FromPyObject<'py> for PyGoogleConfig {
 impl PyGoogleConfig {
     fn apply_config(self, mut builder: GoogleCloudStorageBuilder) -> GoogleCloudStorageBuilder {
         for (key, value) in self.0.into_iter() {
-            builder = builder.with_config(key.0, value);
+            builder = builder.with_config(key.0, value.0);
         }
         builder
     }

--- a/pyo3-object_store/src/lib.rs
+++ b/pyo3-object_store/src/lib.rs
@@ -5,6 +5,7 @@ mod api;
 mod aws;
 mod azure;
 mod client;
+mod config;
 pub(crate) mod error;
 mod gcp;
 mod http;

--- a/tests/store/test_s3.py
+++ b/tests/store/test_s3.py
@@ -15,3 +15,8 @@ async def test_get_async(s3_store: S3Store):
     resp = await obs.get_async(s3_store, "afile")
     buf = await resp.bytes_async()
     assert buf == b"hello world"
+
+
+def test_construct_store_boolean_config():
+    # Should allow boolean parameter
+    S3Store("bucket", skip_signature=True)


### PR DESCRIPTION
### Change list

- Move type hints for config options, client options to `TypedDict`. This enables more detailed typing, as well as support for type hinting kwargs.
- Improved formatting for `bytes.pyi`
- Allow boolean values in config values
- Remove anon method for S3Store (revert #143) and document in class docstring how to pass `skip_signature=True`.
- 

This is a huge DX improvement. Instead of having to put options in a dictionary, we can support them directly.

And we get type hinting at the same type via `Unpack` (https://peps.python.org/pep-0692/, https://typing.readthedocs.io/en/latest/spec/callables.html#unpack-kwargs)

<img width="653" alt="image" src="https://github.com/user-attachments/assets/56f3bb31-186b-435a-9825-40e1e15f49f1" />
