### PR TITLE
Support python timedelta objects as duration config values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1551,6 +1551,7 @@ name = "pyo3-object_store"
 version = "0.1.0-beta.1"
 dependencies = [
  "futures",
+ "humantime",
  "object_store",
  "pyo3",
  "pyo3-async-runtimes",

--- a/obstore/python/obstore/_get.pyi
+++ b/obstore/python/obstore/_get.pyi
@@ -223,7 +223,7 @@ class BytesStream:
 
         To fix this, set the `timeout` parameter in the `client_options` passed to the
         initial `get` or `get_async` call. See
-        [ClientConfigKey][obstore.store.ClientConfigKey].
+        [ClientConfig][obstore.store.ClientConfig].
     """
 
     def __aiter__(self) -> BytesStream:

--- a/obstore/python/obstore/store/_client.pyi
+++ b/obstore/python/obstore/store/_client.pyi
@@ -1,7 +1,32 @@
+from datetime import timedelta
 from typing import TypedDict
 
 class ClientConfig(TypedDict, total=False):
-    """HTTP client configuration"""
+    """HTTP client configuration
+
+    For timeout values (`connect_timeout`, `http2_keep_alive_timeout`,
+    `pool_idle_timeout`, and `timeout`), values can either be Python `timedelta`
+    objects, or they can be "human-readable duration strings".
+
+    The human-readable duration string is a concatenation of time spans. Where each time
+    span is an integer number and a suffix. Supported suffixes:
+
+    - `nsec`, `ns` -- nanoseconds
+    - `usec`, `us` -- microseconds
+    - `msec`, `ms` -- milliseconds
+    - `seconds`, `second`, `sec`, `s`
+    - `minutes`, `minute`, `min`, `m`
+    - `hours`, `hour`, `hr`, `h`
+    - `days`, `day`, `d`
+    - `weeks`, `week`, `w`
+    - `months`, `month`, `M` -- defined as 30.44 days
+    - `years`, `year`, `y` -- defined as 365.25 days
+
+    For example:
+
+    - `"2h 37min"`
+    - `"32ms"`
+    """
 
     allow_http: bool
     """Allow non-TLS, i.e. non-HTTPS connections."""
@@ -16,7 +41,7 @@ class ClientConfig(TypedDict, total=False):
         introduces significant vulnerabilities, and should only be used
         as a last resort or for testing
     """
-    connect_timeout: str
+    connect_timeout: str | timedelta
     """Timeout for only the connect phase of a Client"""
     default_content_type: str
     """default `CONTENT_TYPE` for uploads"""
@@ -24,13 +49,13 @@ class ClientConfig(TypedDict, total=False):
     """Only use http1 connections."""
     http2_keep_alive_interval: str
     """Interval for HTTP2 Ping frames should be sent to keep a connection alive."""
-    http2_keep_alive_timeout: str
+    http2_keep_alive_timeout: str | timedelta
     """Timeout for receiving an acknowledgement of the keep-alive ping."""
     http2_keep_alive_while_idle: str
     """Enable HTTP2 keep alive pings for idle connections"""
     http2_only: bool
     """Only use http2 connections"""
-    pool_idle_timeout: str
+    pool_idle_timeout: str | timedelta
     """The pool max idle timeout.
 
     This is the length of time an idle connection will be kept alive.
@@ -39,7 +64,7 @@ class ClientConfig(TypedDict, total=False):
     """Maximum number of idle connections per host."""
     proxy_url: str
     """HTTP proxy to use for requests."""
-    timeout: str
+    timeout: str | timedelta
     """Request timeout.
 
     The timeout is applied from when the request starts connecting until the

--- a/pyo3-object_store/Cargo.toml
+++ b/pyo3-object_store/Cargo.toml
@@ -15,6 +15,8 @@ include = ["src", "type-hints", "README.md", "LICENSE"]
 
 [dependencies]
 futures = "0.3"
+# This is already an object_store dependency
+humantime = "2.1"
 object_store = { version = "0.11.2", features = [
     "aws",
     "azure",

--- a/pyo3-object_store/src/config.rs
+++ b/pyo3-object_store/src/config.rs
@@ -1,11 +1,15 @@
+use std::time::Duration;
+
+use humantime::format_duration;
 use pyo3::prelude::*;
 
 /// A wrapper around `String` used to store values for config values.
 ///
 /// Supported Python input:
 ///
-/// - str
 /// - `True` and `False` (becomes `"true"` and `"false"`)
+/// - `timedelta`
+/// - `str`
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct PyConfigValue(pub String);
 
@@ -13,6 +17,8 @@ impl<'py> FromPyObject<'py> for PyConfigValue {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         if let Ok(val) = ob.extract::<bool>() {
             Ok(Self(val.to_string()))
+        } else if let Ok(duration) = ob.extract::<Duration>() {
+            Ok(Self(format_duration(duration).to_string()))
         } else {
             Ok(Self(ob.extract()?))
         }

--- a/tests/store/test_config.py
+++ b/tests/store/test_config.py
@@ -1,0 +1,9 @@
+from datetime import timedelta
+
+from obstore.store import HTTPStore
+
+
+def test_config_timedelta():
+    HTTPStore.from_url(
+        "https://example.com", client_options={"timeout": timedelta(seconds=30)}
+    )


### PR DESCRIPTION
Previously duration-typed config values had to be a human-readable string (parseable by [`humantime::parse_duration`](https://docs.rs/humantime/latest/humantime/fn.parse_duration.html))