### PR TITLE
Fix pylance finding exceptions module

### DIFF
--- a/obstore/python/obstore/__init__.py
+++ b/obstore/python/obstore/__init__.py
@@ -4,6 +4,6 @@ from ._obstore import *
 from ._obstore import ___version
 
 if TYPE_CHECKING:
-    from . import store
+    from . import exceptions, store
 
 __version__: str = ___version()

--- a/obstore/python/obstore/exceptions/__init__.pyi
+++ b/obstore/python/obstore/exceptions/__init__.pyi
@@ -1,3 +1,7 @@
+# Note: This should be able to be an `exceptions.pyi` file one level above, however
+# pylance isn't able to find that. So this is an exceptions module with only
+# `__init__.pyi` to work around pylance's bug.
+
 class ObstoreError(Exception):
     """The base exception class"""
 


### PR DESCRIPTION
As noted in the file comment:

> Note: This should be able to be an `exceptions.pyi` file one level above, however
> pylance isn't able to find that. So this is an exceptions module with only
> `__init__.pyi` to work around pylance's bug.
