### PR TITLE
proof of concept: Pickle support 

### DIFF
--- a/pyo3-object_store/src/client.rs
+++ b/pyo3-object_store/src/client.rs
@@ -21,7 +21,7 @@ impl<'py> FromPyObject<'py> for PyClientConfigKey {
 }
 
 /// A wrapper around `ClientOptions` that implements [`FromPyObject`].
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct PyClientOptions(ClientOptions);
 
 impl<'py> FromPyObject<'py> for PyClientOptions {

--- a/pyo3-object_store/src/config.rs
+++ b/pyo3-object_store/src/config.rs
@@ -10,7 +10,7 @@ use pyo3::prelude::*;
 /// - `True` and `False` (becomes `"true"` and `"false"`)
 /// - `timedelta`
 /// - `str`
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, IntoPyObject)]
 pub struct PyConfigValue(pub String);
 
 impl<'py> FromPyObject<'py> for PyConfigValue {

--- a/pyo3-object_store/src/retry.rs
+++ b/pyo3-object_store/src/retry.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use object_store::{BackoffConfig, RetryConfig};
 use pyo3::prelude::*;
 
-#[derive(Debug, FromPyObject)]
+#[derive(Clone, Debug, FromPyObject)]
 #[pyo3(from_item_all)]
 pub struct PyBackoffConfig {
     init_backoff: Duration,
@@ -21,7 +21,7 @@ impl From<PyBackoffConfig> for BackoffConfig {
     }
 }
 
-#[derive(Debug, FromPyObject)]
+#[derive(Clone, Debug, FromPyObject)]
 #[pyo3(from_item_all)]
 pub struct PyRetryConfig {
     backoff: PyBackoffConfig,

--- a/tests/store/test_s3.py
+++ b/tests/store/test_s3.py
@@ -1,3 +1,6 @@
+import pickle
+
+import cloudpickle
 import pytest
 
 import obstore as obs
@@ -33,3 +36,16 @@ def test_error_overlapping_config_kwargs():
 
     with pytest.raises(ObstoreError, match="Duplicate key"):
         S3Store("bucket", config={"AWS_SKIP_SIGNATURE": True}, skip_signature=True)
+
+
+def test_pickle():
+    store = S3Store(
+        "ookla-open-data",
+        region="us-west-2",
+        skip_signature=True,
+    )
+    pickle.loads(pickle.dumps(store))
+
+    test = cloudpickle.dumps(store)
+    restored = cloudpickle.loads(test)
+    objects = next(obs.list(restored))


### PR DESCRIPTION
[Pickle support](https://github.com/developmentseed/obstore/issues/125) is important but hard to implement. 

## Background

There are two ways to implement pickle support. 

1. Implementing [`__getstate__`](https://docs.python.org/3/library/pickle.html#object.__getstate__) and [`__setstate__`](https://docs.python.org/3/library/pickle.html#object.__setstate__). The return value of `__getstate__` can be pretty much anything I think, and that gets passed back into `__setstate__` to 
2. Implementing a constructor (tagged in Rust with `#[new]`) and [`__getnewargs_ex__`](https://docs.python.org/3/library/pickle.html#object.__getnewargs_ex__). `__getnewargs_ex__` must return a tuple of `(args: tuple, kwargs: dict)`, which can be passed to the `#[new]` constructor. This can be simpler when you already have a `#[new]` implemented and when the parameters into that `#[new]` function are easily serializable. However it might require  (I wonder if there's a way to recursively pickle things?)

We can't extract the configuration out from a "finished" `object_store` instance like an [`AmazonS3`](https://docs.rs/object_store/latest/object_store/aws/struct.AmazonS3.html). We could extract some configuration out of a builder instance like [`AmazonS3Builder`](https://docs.rs/object_store/latest/object_store/aws/struct.AmazonS3Builder.html), but then _every time we use that class_ we'd have to call `build()` on the Rust side, which would probably significantly hurt performance. Therefore, the only(?) possible way to implement pickle support inside obstore is to persist the store configuration separately inside the `#[pyclass]`.

## Implementation

- Store configuration information _a second time_ in the `#[pyclass]` of each store. (It's already implicitly stored by the underlying rust `ObjectStore` instance.
- Implement `__getnewargs_ex__`, returning the parameters passed to `#[new]`
- Implement `IntoPyObject` for each configuration object: the store-specific config, client options, and retry options

## Benefits

- It should be relatively straightforward to implement for any of the raw stores: `S3Store`, `GCSStore`, `AzureStore`, `LocalStore`, and `MemoryStore`.
- We're already validating the `PyAmazonS3Config`, `PyClientOptions`, and `PyRetryConfig`, so it isn't that much extra work just to store those on the Rust class. So we can serialize them to Python objects in `__getnewargs_ex__` and then have Python automatically pass them to `#[new]`.
- Using `__getnewargs_ex__` means we don't need to add serde support; we can use `IntoPyObject` and `FromPyObject` for all (de)serialization and only have a single code path.
- We can persist all of the store-specific config, the client options, and the retry config, so the pickled instances should be _exactly_ the same as the original instances.
- Supports any of the builder classmethods, e.g. `from_env`, `from_url`, etc,
- Most of the time, storing configuration information should be just a few strings. So ideally it'll increase memory usage only slightly, and won't affect runtime performance otherwise (assuming you reuse a store instead of creating a new one each time).
- Since we don't allow the store classes to be mutated after creation from Python, there's no risk of the two copies of the configuration getting out of sync.


## Drawbacks

- Unclear how to support middleware, including `PrefixStore`, because those have to support an _arbitrary_ wrapped object. Is there a way to recursively pickle and unpickle the thing it's wrapping?
	- If we can't find a way to support pickling of arbitrary middleware, we could alternatively use a `PrefixStore` internally and automatically inside an `S3Store`, `GCSStore`, `AzureStore` (NOTE: we should maybe benchmark the overhead a `PrefixStore` causes, in case it's something we don't want to force on everyone? Well, if the `S3Store` stored an arbitrary `Arc<dyn ObjectStore>` then we could prefix when asked for and not prefix when not asked for, but maybe that would conflict with signing, if that requires a raw `object_store::AmazonS3` instance?). Alternatively, we could create the `PrefixStore` on demand, since it [looks virtually free](https://github.com/apache/arrow-rs/blob/3bf29a2c7474e59722d885cd11fafd0dca13a28e/object_store/src/prefix.rs#L44-L49).
- `MemoryStore` won't copy its state, but that's unavoidable I think. (Should be documented)

## Todo

- [ ] Implement `IntoPyObject` for `ClientOptions` and `RetryConfig`.
- [ ] Docs page on pickling and any gotchas (e.g. MemoryStore and PrefixStore limitations).

(Note, we should probably add this issue content to a dev doc)

Closes https://github.com/developmentseed/obstore/issues/125