### PR TITLE
Make ObjectStore a base class instead of a type

### DIFF
--- a/pyo3-object_store/src/api.rs
+++ b/pyo3-object_store/src/api.rs
@@ -3,7 +3,8 @@ use pyo3::prelude::*;
 
 use crate::error::*;
 use crate::{
-    PyAzureStore, PyGCSStore, PyHttpStore, PyLocalStore, PyMemoryStore, PyPrefixStore, PyS3Store,
+    PyAzureStore, PyBaseObjectStore, PyGCSStore, PyHttpStore, PyLocalStore, PyMemoryStore,
+    PyPrefixStore, PyS3Store,
 };
 
 /// Export the default Python API as a submodule named `store` within the given parent module
@@ -46,6 +47,7 @@ pub fn register_store_module(
 
     let child_module = PyModule::new(parent_module.py(), "store")?;
 
+    child_module.add_class::<PyBaseObjectStore>()?;
     child_module.add_class::<PyAzureStore>()?;
     child_module.add_class::<PyGCSStore>()?;
     child_module.add_class::<PyHttpStore>()?;

--- a/pyo3-object_store/src/base.rs
+++ b/pyo3-object_store/src/base.rs
@@ -1,0 +1,5 @@
+use pyo3::prelude::*;
+
+/// Base class from which all other stores subclass
+#[pyclass(name = "BaseObjectStore", frozen, subclass)]
+pub struct PyBaseObjectStore {}

--- a/pyo3-object_store/src/lib.rs
+++ b/pyo3-object_store/src/lib.rs
@@ -4,6 +4,7 @@
 mod api;
 mod aws;
 mod azure;
+mod base;
 mod client;
 mod config;
 pub(crate) mod error;
@@ -18,6 +19,7 @@ mod store;
 pub use api::{register_exceptions_module, register_store_module};
 pub use aws::PyS3Store;
 pub use azure::PyAzureStore;
+pub use base::PyBaseObjectStore;
 pub use client::{PyClientConfigKey, PyClientOptions};
 pub use error::{PyObjectStoreError, PyObjectStoreResult};
 pub use gcp::PyGCSStore;


### PR DESCRIPTION
## Available PR templates

<!--
  Github doesn't allow PR template selection the same way that it is possible with issues.
  Preview this and select the appropriate template
-->

- [Default](?expand=1&template=default.md)
- [Version Release](?expand=1&template=version_release.md)
- _Alternatively delete and start empty_
