### PR TITLE
Standardize on obstore's NotFoundError

### DIFF
--- a/pyo3-object_store/src/error.rs
+++ b/pyo3-object_store/src/error.rs
@@ -1,7 +1,7 @@
 //! Contains the [`PyObjectStoreError`], the error enum returned by all fallible functions in this
 //! crate.
 
-use pyo3::exceptions::{PyFileNotFoundError, PyIOError, PyNotImplementedError, PyValueError};
+use pyo3::exceptions::{PyIOError, PyNotImplementedError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::{create_exception, DowncastError};
 use thiserror::Error;
@@ -111,7 +111,7 @@ impl From<PyObjectStoreError> for PyErr {
                     source: _,
                 } => GenericError::new_err(format!("{err:#?}")),
                 object_store::Error::NotFound { path: _, source: _ } => {
-                    PyFileNotFoundError::new_err(format!("{err:#?}"))
+                    NotFoundError::new_err(format!("{err:#?}"))
                 }
                 object_store::Error::InvalidPath { source: _ } => {
                     InvalidPathError::new_err(format!("{err:#?}"))


### PR DESCRIPTION
## Available PR templates

<!--
  Github doesn't allow PR template selection the same way that it is possible with issues.
  Preview this and select the appropriate template
-->

- [Default](?expand=1&template=default.md)
- [Version Release](?expand=1&template=version_release.md)
- _Alternatively delete and start empty_
