### PR TITLE
Rename ObstoreError to BaseError

### DIFF
--- a/obstore/python/obstore/exceptions/__init__.pyi
+++ b/obstore/python/obstore/exceptions/__init__.pyi
@@ -2,41 +2,41 @@
 # pylance isn't able to find that. So this is an exceptions module with only
 # `__init__.pyi` to work around pylance's bug.
 
-class ObstoreError(Exception):
+class BaseError(Exception):
     """The base exception class"""
 
-class GenericError(ObstoreError):
+class GenericError(BaseError):
     """A fallback error type when no variant matches."""
 
-class NotFoundError(ObstoreError):
+class NotFoundError(BaseError):
     """Error when the object is not found at given location."""
 
-class InvalidPathError(ObstoreError):
+class InvalidPathError(BaseError):
     """Error for invalid path."""
 
-class JoinError(ObstoreError):
+class JoinError(BaseError):
     """Error when `tokio::spawn` failed."""
 
-class NotSupportedError(ObstoreError):
+class NotSupportedError(BaseError):
     """Error when the attempted operation is not supported."""
 
-class AlreadyExistsError(ObstoreError):
+class AlreadyExistsError(BaseError):
     """Error when the object already exists."""
 
-class PreconditionError(ObstoreError):
+class PreconditionError(BaseError):
     """Error when the required conditions failed for the operation."""
 
-class NotModifiedError(ObstoreError):
+class NotModifiedError(BaseError):
     """Error when the object at the location isn't modified."""
 
-class PermissionDeniedError(ObstoreError):
+class PermissionDeniedError(BaseError):
     """
     Error when the used credentials don't have enough permission
     to perform the requested operation
     """
 
-class UnauthenticatedError(ObstoreError):
+class UnauthenticatedError(BaseError):
     """Error when the used credentials lack valid authentication."""
 
-class UnknownConfigurationKeyError(ObstoreError):
+class UnknownConfigurationKeyError(BaseError):
     """Error when a configuration key is invalid for the store used."""

--- a/pyo3-object_store/src/api.rs
+++ b/pyo3-object_store/src/api.rs
@@ -78,7 +78,7 @@ pub fn register_exceptions_module(
 
     let child_module = PyModule::new(parent_module.py(), "exceptions")?;
 
-    child_module.add("ObstoreError", py.get_type::<ObstoreError>())?;
+    child_module.add("BaseError", py.get_type::<BaseError>())?;
     child_module.add("GenericError", py.get_type::<GenericError>())?;
     child_module.add("NotFoundError", py.get_type::<NotFoundError>())?;
     child_module.add("InvalidPathError", py.get_type::<InvalidPathError>())?;

--- a/pyo3-object_store/src/aws.rs
+++ b/pyo3-object_store/src/aws.rs
@@ -11,7 +11,7 @@ use pyo3::{intern, IntoPyObjectExt};
 
 use crate::client::PyClientOptions;
 use crate::config::PyConfigValue;
-use crate::error::{ObstoreError, PyObjectStoreError, PyObjectStoreResult};
+use crate::error::{GenericError, PyObjectStoreError, PyObjectStoreResult};
 use crate::path::PyPath;
 use crate::prefix::MaybePrefixedStore;
 use crate::retry::PyRetryConfig;
@@ -313,7 +313,7 @@ impl PyAmazonS3Config {
         for (k, v) in other.0.into_iter() {
             let old_value = self.0.insert(k.clone(), v);
             if old_value.is_some() {
-                return Err(ObstoreError::new_err(format!(
+                return Err(GenericError::new_err(format!(
                     "Duplicate key {} between config and kwargs",
                     k.0.as_ref()
                 ))

--- a/pyo3-object_store/src/azure.rs
+++ b/pyo3-object_store/src/azure.rs
@@ -11,7 +11,7 @@ use pyo3::{intern, IntoPyObjectExt};
 
 use crate::client::PyClientOptions;
 use crate::config::PyConfigValue;
-use crate::error::{ObstoreError, PyObjectStoreError, PyObjectStoreResult};
+use crate::error::{GenericError, PyObjectStoreError, PyObjectStoreResult};
 use crate::path::PyPath;
 use crate::retry::PyRetryConfig;
 use crate::{MaybePrefixedStore, PyUrl};
@@ -238,7 +238,7 @@ impl PyAzureConfig {
         for (k, v) in other.0.into_iter() {
             let old_value = self.0.insert(k.clone(), v);
             if old_value.is_some() {
-                return Err(ObstoreError::new_err(format!(
+                return Err(GenericError::new_err(format!(
                     "Duplicate key {} between config and kwargs",
                     k.0.as_ref()
                 ))

--- a/pyo3-object_store/src/error.rs
+++ b/pyo3-object_store/src/error.rs
@@ -7,9 +7,11 @@ use pyo3::{create_exception, DowncastError};
 use thiserror::Error;
 
 // Base exception
+// Note that this is named `BaseError` instead of `ObstoreError` to not leak the name "obstore" to
+// other Rust-Python libraries using pyo3-object_store.
 create_exception!(
     pyo3_object_store,
-    ObstoreError,
+    BaseError,
     pyo3::exceptions::PyException,
     "The base Python-facing exception from which all other errors subclass."
 );
@@ -18,67 +20,67 @@ create_exception!(
 create_exception!(
     pyo3_object_store,
     GenericError,
-    ObstoreError,
+    BaseError,
     "A Python-facing exception wrapping [object_store::Error::Generic]."
 );
 create_exception!(
     pyo3_object_store,
     NotFoundError,
-    ObstoreError,
+    BaseError,
     "A Python-facing exception wrapping [object_store::Error::NotFound]."
 );
 create_exception!(
     pyo3_object_store,
     InvalidPathError,
-    ObstoreError,
+    BaseError,
     "A Python-facing exception wrapping [object_store::Error::InvalidPath]."
 );
 create_exception!(
     pyo3_object_store,
     JoinError,
-    ObstoreError,
+    BaseError,
     "A Python-facing exception wrapping [object_store::Error::JoinError]."
 );
 create_exception!(
     pyo3_object_store,
     NotSupportedError,
-    ObstoreError,
+    BaseError,
     "A Python-facing exception wrapping [object_store::Error::NotSupported]."
 );
 create_exception!(
     pyo3_object_store,
     AlreadyExistsError,
-    ObstoreError,
+    BaseError,
     "A Python-facing exception wrapping [object_store::Error::AlreadyExists]."
 );
 create_exception!(
     pyo3_object_store,
     PreconditionError,
-    ObstoreError,
+    BaseError,
     "A Python-facing exception wrapping [object_store::Error::Precondition]."
 );
 create_exception!(
     pyo3_object_store,
     NotModifiedError,
-    ObstoreError,
+    BaseError,
     "A Python-facing exception wrapping [object_store::Error::NotModified]."
 );
 create_exception!(
     pyo3_object_store,
     PermissionDeniedError,
-    ObstoreError,
+    BaseError,
     "A Python-facing exception wrapping [object_store::Error::PermissionDenied]."
 );
 create_exception!(
     pyo3_object_store,
     UnauthenticatedError,
-    ObstoreError,
+    BaseError,
     "A Python-facing exception wrapping [object_store::Error::Unauthenticated]."
 );
 create_exception!(
     pyo3_object_store,
     UnknownConfigurationKeyError,
-    ObstoreError,
+    BaseError,
     "A Python-facing exception wrapping [object_store::Error::UnknownConfigurationKey]."
 );
 

--- a/pyo3-object_store/src/gcp.rs
+++ b/pyo3-object_store/src/gcp.rs
@@ -11,7 +11,7 @@ use pyo3::{intern, IntoPyObjectExt};
 
 use crate::client::PyClientOptions;
 use crate::config::PyConfigValue;
-use crate::error::{ObstoreError, PyObjectStoreError, PyObjectStoreResult};
+use crate::error::{GenericError, PyObjectStoreError, PyObjectStoreResult};
 use crate::path::PyPath;
 use crate::retry::PyRetryConfig;
 use crate::{MaybePrefixedStore, PyUrl};
@@ -236,7 +236,7 @@ impl PyGoogleConfig {
         for (k, v) in other.0.into_iter() {
             let old_value = self.0.insert(k.clone(), v);
             if old_value.is_some() {
-                return Err(ObstoreError::new_err(format!(
+                return Err(GenericError::new_err(format!(
                     "Duplicate key {} between config and kwargs",
                     k.0.as_ref()
                 ))

--- a/pyo3-object_store/src/simple.rs
+++ b/pyo3-object_store/src/simple.rs
@@ -6,7 +6,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyType};
 use pyo3::{intern, IntoPyObjectExt};
 
-use crate::error::ObstoreError;
+use crate::error::GenericError;
 use crate::retry::PyRetryConfig;
 use crate::url::PyUrl;
 use crate::{
@@ -100,7 +100,7 @@ pub fn from_url(
             Ok(store.into_pyobject(py)?.into_py_any(py)?)
         }
         scheme => {
-            return Err(ObstoreError::new_err(format!("Unknown URL scheme {:?}", scheme,)).into());
+            return Err(GenericError::new_err(format!("Unknown URL scheme {:?}", scheme,)).into());
         }
     }
 }
@@ -111,7 +111,7 @@ fn raise_if_config_passed(
     scheme: &str,
 ) -> PyObjectStoreResult<()> {
     if config.is_some() || kwargs.is_some() {
-        return Err(ObstoreError::new_err(format!(
+        return Err(GenericError::new_err(format!(
             "Cannot pass config or keyword parameters for scheme {:?}",
             scheme,
         ))

--- a/tests/store/test_from_url.py
+++ b/tests/store/test_from_url.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from obstore.exceptions import ObstoreError, UnknownConfigurationKeyError
+from obstore.exceptions import BaseError, UnknownConfigurationKeyError
 from obstore.store import from_url
 
 
@@ -16,7 +16,7 @@ def test_memory():
     url = "memory:///"
     _store = from_url(url)
 
-    with pytest.raises(ObstoreError):
+    with pytest.raises(BaseError):
         from_url(url, aws_access_key_id="test")
 
 
@@ -51,5 +51,5 @@ def test_http():
     url = "https://mydomain/path"
     from_url(url)
 
-    with pytest.raises(ObstoreError):
+    with pytest.raises(BaseError):
         from_url(url, aws_bucket="test")

--- a/tests/store/test_s3.py
+++ b/tests/store/test_s3.py
@@ -4,7 +4,7 @@ import pickle
 import pytest
 
 import obstore as obs
-from obstore.exceptions import ObstoreError
+from obstore.exceptions import BaseError
 from obstore.store import S3Store, from_url
 
 
@@ -27,14 +27,14 @@ def test_construct_store_boolean_config():
 
 
 def test_error_overlapping_config_kwargs():
-    with pytest.raises(ObstoreError, match="Duplicate key"):
+    with pytest.raises(BaseError, match="Duplicate key"):
         S3Store("bucket", config={"skip_signature": True}, skip_signature=True)
 
     # Also raises for variations of the same parameter
-    with pytest.raises(ObstoreError, match="Duplicate key"):
+    with pytest.raises(BaseError, match="Duplicate key"):
         S3Store("bucket", config={"aws_skip_signature": True}, skip_signature=True)
 
-    with pytest.raises(ObstoreError, match="Duplicate key"):
+    with pytest.raises(BaseError, match="Duplicate key"):
         S3Store("bucket", config={"AWS_SKIP_SIGNATURE": True}, skip_signature=True)
 
 


### PR DESCRIPTION
Renaming `ObstoreError` to `BaseError` to not leak the name "obstore" to other Rust-Python libraries using pyo3-object_store.

cc @ion-elgreco 
