### PR TITLE
Vendor upstream URL parsing to simplify internal config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1554,6 +1554,7 @@ dependencies = [
  "bytes",
  "futures",
  "humantime",
+ "itertools",
  "object_store",
  "pyo3",
  "pyo3-async-runtimes",

--- a/pyo3-object_store/Cargo.toml
+++ b/pyo3-object_store/Cargo.toml
@@ -19,6 +19,8 @@ bytes = "1"
 futures = "0.3"
 # This is already an object_store dependency
 humantime = "2.1"
+# This is already an object_store dependency
+itertools = "0.14.0"
 object_store = { version = "0.11.2", features = [
     "aws",
     "azure",

--- a/pyo3-object_store/src/aws.rs
+++ b/pyo3-object_store/src/aws.rs
@@ -21,25 +21,29 @@ use crate::PyUrl;
 
 #[derive(Debug, Clone)]
 struct S3Config {
-    bucket: Option<String>,
     prefix: Option<PyPath>,
-    config: Option<PyAmazonS3Config>,
+    config: PyAmazonS3Config,
     client_options: Option<PyClientOptions>,
     retry_config: Option<PyRetryConfig>,
 }
 
 impl S3Config {
+    fn bucket(&self) -> &str {
+        self.config
+            .0
+            .get(&PyAmazonS3ConfigKey(AmazonS3ConfigKey::Bucket))
+            .expect("bucket should always exist in the config")
+            .as_ref()
+    }
+
     fn __getnewargs_ex__(&self, py: Python) -> PyResult<PyObject> {
-        let args =
-            PyTuple::new(py, vec![self.bucket.clone().into_pyobject(py)?])?.into_py_any(py)?;
+        let args = PyTuple::empty(py).into_py_any(py)?;
         let kwargs = PyDict::new(py);
 
         if let Some(prefix) = &self.prefix {
             kwargs.set_item(intern!(py, "prefix"), prefix.as_ref().as_ref())?;
         }
-        if let Some(config) = &self.config {
-            kwargs.set_item(intern!(py, "config"), config.clone())?;
-        }
+        kwargs.set_item(intern!(py, "config"), self.config.clone())?;
         if let Some(client_options) = &self.client_options {
             kwargs.set_item(intern!(py, "client_options"), client_options.clone())?;
         }
@@ -75,13 +79,14 @@ impl PyS3Store {
         retry_config: Option<PyRetryConfig>,
         kwargs: Option<PyAmazonS3Config>,
     ) -> PyObjectStoreResult<Self> {
-        if let Some(bucket) = bucket.clone() {
-            builder = builder.with_bucket_name(bucket);
+        let mut config = config.unwrap_or_default();
+        if let Some(bucket) = bucket {
+            // Note: we apply the bucket to the config, not directly to the builder, so they stay
+            // in sync.
+            config.insert_raising_if_exists(AmazonS3ConfigKey::Bucket, bucket)?;
         }
         let combined_config = combine_config_kwargs(config, kwargs)?;
-        if let Some(config_kwargs) = combined_config.clone() {
-            builder = config_kwargs.apply_config(builder);
-        }
+        builder = combined_config.clone().apply_config(builder);
         if let Some(client_options) = client_options.clone() {
             builder = builder.with_client_options(client_options.into())
         }
@@ -92,7 +97,6 @@ impl PyS3Store {
             store: Arc::new(MaybePrefixedStore::new(builder.build()?, prefix.clone())),
             config: S3Config {
                 prefix,
-                bucket,
                 config: combined_config,
                 client_options,
                 retry_config,
@@ -232,18 +236,15 @@ impl PyS3Store {
     }
 
     fn __repr__(&self) -> String {
-        if let Some(bucket) = &self.config.bucket {
-            if let Some(prefix) = &self.config.prefix {
-                format!(
-                    "S3Store(bucket=\"{}\", prefix=\"{}\")",
-                    bucket,
-                    prefix.as_ref()
-                )
-            } else {
-                format!("S3Store(bucket=\"{}\")", bucket)
-            }
+        let bucket = self.config.bucket();
+        if let Some(prefix) = &self.config.prefix {
+            format!(
+                "S3Store(bucket=\"{}\", prefix=\"{}\")",
+                bucket,
+                prefix.as_ref()
+            )
         } else {
-            "S3Store".to_string()
+            format!("S3Store(bucket=\"{}\")", bucket)
         }
     }
 }
@@ -307,18 +308,29 @@ impl PyAmazonS3Config {
     }
 
     fn merge(mut self, other: PyAmazonS3Config) -> PyObjectStoreResult<PyAmazonS3Config> {
-        for (k, v) in other.0.into_iter() {
-            let old_value = self.0.insert(k.clone(), v);
-            if old_value.is_some() {
-                return Err(GenericError::new_err(format!(
-                    "Duplicate key {} between config and kwargs",
-                    k.0.as_ref()
-                ))
-                .into());
-            }
+        for (key, val) in other.0.into_iter() {
+            self.insert_raising_if_exists(key, val)?;
         }
 
         Ok(self)
+    }
+
+    fn insert_raising_if_exists(
+        &mut self,
+        key: impl Into<PyAmazonS3ConfigKey>,
+        val: impl Into<String>,
+    ) -> PyObjectStoreResult<()> {
+        let key = key.into();
+        let old_value = self.0.insert(key.clone(), PyConfigValue::new(val.into()));
+        if old_value.is_some() {
+            return Err(GenericError::new_err(format!(
+                "Duplicate key {} between config and kwargs",
+                key.0.as_ref()
+            ))
+            .into());
+        }
+
+        Ok(())
     }
 
     /// Insert a key only if it does not already exist.
@@ -335,13 +347,13 @@ impl PyAmazonS3Config {
 }
 
 fn combine_config_kwargs(
-    config: Option<PyAmazonS3Config>,
+    config: PyAmazonS3Config,
     kwargs: Option<PyAmazonS3Config>,
-) -> PyObjectStoreResult<Option<PyAmazonS3Config>> {
-    match (config, kwargs) {
-        (None, None) => Ok(None),
-        (Some(x), None) | (None, Some(x)) => Ok(Some(x)),
-        (Some(config), Some(kwargs)) => Ok(Some(config.merge(kwargs)?)),
+) -> PyObjectStoreResult<PyAmazonS3Config> {
+    if let Some(kwargs) = kwargs {
+        config.merge(kwargs)
+    } else {
+        Ok(config)
     }
 }
 

--- a/pyo3-object_store/src/azure.rs
+++ b/pyo3-object_store/src/azure.rs
@@ -8,20 +8,17 @@ use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedStr;
 use pyo3::types::{PyDict, PyString, PyTuple, PyType};
 use pyo3::{intern, IntoPyObjectExt};
+use url::Url;
 
 use crate::client::PyClientOptions;
 use crate::config::PyConfigValue;
-use crate::error::{GenericError, PyObjectStoreError, PyObjectStoreResult};
+use crate::error::{GenericError, ParseUrlError, PyObjectStoreError, PyObjectStoreResult};
 use crate::path::PyPath;
 use crate::retry::PyRetryConfig;
 use crate::{MaybePrefixedStore, PyUrl};
 
 struct AzureConfig {
     container: Option<String>,
-    // Note: we need to persist the URL passed in via from_url because object_store defers the URL
-    // parsing until its `build` method, and then we have no way to persist the state of its parsed
-    // components.
-    url: Option<PyUrl>,
     prefix: Option<PyPath>,
     config: Option<PyAzureConfig>,
     client_options: Option<PyClientOptions>,
@@ -36,9 +33,6 @@ impl AzureConfig {
 
         if let Some(prefix) = &self.prefix {
             kwargs.set_item(intern!(py, "prefix"), prefix.as_ref().as_ref())?;
-        }
-        if let Some(url) = &self.url {
-            kwargs.set_item(intern!(py, "url"), url.as_ref().as_str())?;
         }
         if let Some(config) = &self.config {
             kwargs.set_item(intern!(py, "config"), config.clone())?;
@@ -79,23 +73,18 @@ impl PyAzureStore {
 impl PyAzureStore {
     // Create from parameters
     #[new]
-    #[pyo3(signature = (container=None, *, prefix=None, config=None, client_options=None, retry_config=None, url=None, **kwargs))]
+    #[pyo3(signature = (container=None, *, prefix=None, config=None, client_options=None, retry_config=None, **kwargs))]
     fn new(
         container: Option<String>,
         prefix: Option<PyPath>,
         config: Option<PyAzureConfig>,
         client_options: Option<PyClientOptions>,
         retry_config: Option<PyRetryConfig>,
-        // Note: URL is undocumented in the type hint as it's only used for pickle support.
-        url: Option<PyUrl>,
         kwargs: Option<PyAzureConfig>,
     ) -> PyObjectStoreResult<Self> {
         let mut builder = MicrosoftAzureBuilder::from_env();
         if let Some(container) = container.clone() {
             builder = builder.with_container_name(container);
-        }
-        if let Some(url) = url.clone() {
-            builder = builder.with_url(url);
         }
         let combined_config = combine_config_kwargs(config, kwargs)?;
         if let Some(config_kwargs) = combined_config.clone() {
@@ -111,7 +100,6 @@ impl PyAzureStore {
             store: Arc::new(MaybePrefixedStore::new(builder.build()?, prefix.clone())),
             config: AzureConfig {
                 prefix,
-                url,
                 container,
                 config: combined_config,
                 client_options,
@@ -140,8 +128,9 @@ impl PyAzureStore {
             None
         };
 
+        let config = parse_url(config, url.as_ref())?;
         let mut builder = MicrosoftAzureBuilder::from_env().with_url(url.clone());
-        let combined_config = combine_config_kwargs(config, kwargs)?;
+        let combined_config = combine_config_kwargs(Some(config), kwargs)?;
         if let Some(config_kwargs) = combined_config.clone() {
             builder = config_kwargs.apply_config(builder);
         }
@@ -155,7 +144,6 @@ impl PyAzureStore {
             store: Arc::new(MaybePrefixedStore::new(builder.build()?, prefix.clone())),
             config: AzureConfig {
                 prefix,
-                url: Some(url),
                 container: None,
                 config: combined_config,
                 client_options,
@@ -180,8 +168,6 @@ impl PyAzureStore {
             } else {
                 format!("AzureStore(container=\"{}\")", container)
             }
-        } else if let Some(url) = &self.config.url {
-            format!("AzureStore(url=\"{}\")", url.as_ref())
         } else {
             "AzureStore".to_string()
         }
@@ -215,7 +201,19 @@ impl<'py> IntoPyObject<'py> for PyAzureConfigKey {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, IntoPyObject)]
+impl From<AzureConfigKey> for PyAzureConfigKey {
+    fn from(value: AzureConfigKey) -> Self {
+        Self(value)
+    }
+}
+
+impl From<PyAzureConfigKey> for AzureConfigKey {
+    fn from(value: PyAzureConfigKey) -> Self {
+        value.0
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, IntoPyObject)]
 pub struct PyAzureConfig(HashMap<PyAzureConfigKey, PyConfigValue>);
 
 // Note: we manually impl FromPyObject instead of deriving it so that we can raise an
@@ -248,6 +246,14 @@ impl PyAzureConfig {
 
         Ok(self)
     }
+
+    /// Insert a key only if it does not already exist.
+    ///
+    /// This is used for URL parsing, where any parts of the URL **do not** override any
+    /// configuration keys passed manually.
+    fn insert_if_not_exists(&mut self, key: impl Into<PyAzureConfigKey>, val: impl Into<String>) {
+        self.0.entry(key.into()).or_insert(PyConfigValue::new(val));
+    }
 }
 
 fn combine_config_kwargs(
@@ -259,4 +265,95 @@ fn combine_config_kwargs(
         (Some(x), None) | (None, Some(x)) => Ok(Some(x)),
         (Some(config), Some(kwargs)) => Ok(Some(config.merge(kwargs)?)),
     }
+}
+
+/// Sets properties on this builder based on a URL
+///
+/// This is vendored from
+/// https://github.com/apache/arrow-rs/blob/f7263e253655b2ee613be97f9d00e063444d3df5/object_store/src/azure/builder.rs#L639-L705
+///
+/// We do our own URL parsing so that we can keep our own config in sync with what is passed to the
+/// underlying ObjectStore builder. Passing the URL on verbatim makes it hard because the URL
+/// parsing only happens in `build()`. Then the config parameters we have don't include any config
+/// applied from the URL.
+fn parse_url(config: Option<PyAzureConfig>, parsed: &Url) -> object_store::Result<PyAzureConfig> {
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| ParseUrlError::UrlNotRecognised {
+            url: parsed.as_str().to_string(),
+        })?;
+    let mut config = config.unwrap_or_default();
+
+    let validate = |s: &str| match s.contains('.') {
+        true => Err(ParseUrlError::UrlNotRecognised {
+            url: parsed.as_str().to_string(),
+        }),
+        false => Ok(s.to_string()),
+    };
+
+    match parsed.scheme() {
+        "az" | "adl" | "azure" => {
+            config.insert_if_not_exists(AzureConfigKey::ContainerName, validate(host)?);
+        }
+        "abfs" | "abfss" => {
+            // abfs(s) might refer to the fsspec convention abfs://<container>/<path>
+            // or the convention for the hadoop driver abfs[s]://<file_system>@<account_name>.dfs.core.windows.net/<path>
+            if parsed.username().is_empty() {
+                config.insert_if_not_exists(AzureConfigKey::ContainerName, validate(host)?);
+            } else if let Some(a) = host.strip_suffix(".dfs.core.windows.net") {
+                config.insert_if_not_exists(
+                    AzureConfigKey::ContainerName,
+                    validate(parsed.username())?,
+                );
+                config.insert_if_not_exists(AzureConfigKey::AccountName, validate(a)?);
+            } else if let Some(a) = host.strip_suffix(".dfs.fabric.microsoft.com") {
+                config.insert_if_not_exists(
+                    AzureConfigKey::ContainerName,
+                    validate(parsed.username())?,
+                );
+                config.insert_if_not_exists(AzureConfigKey::AccountName, validate(a)?);
+                config.insert_if_not_exists(AzureConfigKey::UseFabricEndpoint, "true");
+            } else {
+                return Err(ParseUrlError::UrlNotRecognised {
+                    url: parsed.as_str().to_string(),
+                }
+                .into());
+            }
+        }
+        "https" => match host.split_once('.') {
+            Some((a, "dfs.core.windows.net")) | Some((a, "blob.core.windows.net")) => {
+                config.insert_if_not_exists(AzureConfigKey::AccountName, validate(a)?);
+                if let Some(container) = parsed.path_segments().unwrap().next() {
+                    config
+                        .insert_if_not_exists(AzureConfigKey::ContainerName, validate(container)?);
+                }
+            }
+            Some((a, "dfs.fabric.microsoft.com")) | Some((a, "blob.fabric.microsoft.com")) => {
+                config.insert_if_not_exists(AzureConfigKey::AccountName, validate(a)?);
+                // Attempt to infer the container name from the URL
+                // - https://onelake.dfs.fabric.microsoft.com/<workspaceGUID>/<itemGUID>/Files/test.csv
+                // - https://onelake.dfs.fabric.microsoft.com/<workspace>/<item>.<itemtype>/<path>/<fileName>
+                //
+                // See <https://learn.microsoft.com/en-us/fabric/onelake/onelake-access-api>
+                if let Some(workspace) = parsed.path_segments().unwrap().next() {
+                    if !workspace.is_empty() {
+                        config.insert_if_not_exists(AzureConfigKey::ContainerName, workspace);
+                    }
+                }
+                config.insert_if_not_exists(AzureConfigKey::UseFabricEndpoint, "true");
+            }
+            _ => {
+                return Err(ParseUrlError::UrlNotRecognised {
+                    url: parsed.as_str().to_string(),
+                }
+                .into())
+            }
+        },
+        scheme => {
+            let scheme = scheme.into();
+            return Err(ParseUrlError::UnknownUrlScheme { scheme }.into());
+        }
+    }
+
+    Ok(config)
 }

--- a/pyo3-object_store/src/config.rs
+++ b/pyo3-object_store/src/config.rs
@@ -19,6 +19,12 @@ impl PyConfigValue {
     }
 }
 
+impl AsRef<str> for PyConfigValue {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
 impl<'py> FromPyObject<'py> for PyConfigValue {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         if let Ok(val) = ob.extract::<bool>() {

--- a/pyo3-object_store/src/config.rs
+++ b/pyo3-object_store/src/config.rs
@@ -13,6 +13,12 @@ use pyo3::prelude::*;
 #[derive(Clone, Debug, PartialEq, Eq, Hash, IntoPyObject)]
 pub struct PyConfigValue(pub String);
 
+impl PyConfigValue {
+    pub(crate) fn new(val: impl Into<String>) -> Self {
+        Self(val.into())
+    }
+}
+
 impl<'py> FromPyObject<'py> for PyConfigValue {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         if let Ok(val) = ob.extract::<bool>() {

--- a/pyo3-object_store/src/error.rs
+++ b/pyo3-object_store/src/error.rs
@@ -163,3 +163,27 @@ impl<'a, 'py> From<DowncastError<'a, 'py>> for PyObjectStoreError {
 
 /// A type wrapper around `Result<T, PyObjectStoreError>`.
 pub type PyObjectStoreResult<T> = Result<T, PyObjectStoreError>;
+
+/// A specialized `Error` for object store-related errors
+///
+/// Vendored from upstream to handle our vendored URL parsing
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ParseUrlError {
+    #[error(
+        "Unknown url scheme cannot be parsed into storage location: {}",
+        scheme
+    )]
+    UnknownUrlScheme { scheme: String },
+
+    #[error("URL did not match any known pattern for scheme: {}", url)]
+    UrlNotRecognised { url: String },
+}
+
+impl From<ParseUrlError> for object_store::Error {
+    fn from(source: ParseUrlError) -> Self {
+        Self::Generic {
+            store: "S3",
+            source: Box::new(source),
+        }
+    }
+}

--- a/tests/store/test_from_url.py
+++ b/tests/store/test_from_url.py
@@ -33,7 +33,9 @@ def test_s3_params():
 
 def test_gcs_params():
     # Just to test the params. In practice, the bucket shouldn't be passed
-    from_url("gs://test.example.com/path", google_bucket="test_bucket")
+    # Note: we can't pass the bucket name here as a kwarg because it would conflict with
+    # the bucket name in the URL.
+    from_url("gs://test.example.com/path")
 
     with pytest.raises(UnknownConfigurationKeyError):
         from_url("gs://test.example.com/path", azure_authority_id="")


### PR DESCRIPTION
Because `url` has _deferred parsing_ in the `object_store` builders, we need to special-case `url` handling. Naturally, passing `url` to a store with `with_url` means that `object_store` doesn't actually parse the URL until the `build()` method, and at that point we can no longer access config information from the built `AmazonS3`. Without special-casing this URL handling, pickling would fail for instances created from `from_url`.

Therefore, we handle this by vendoring the small amount of URL parsing from upstream. So we apply the URL parsing onto our config `HashMap`s and _then_ apply those to the builder. So our configs and those used by the raw stores stay in sync.

We originally stored the `url` separately, but that meant that the bucket name was stored in up to three different places (`bucket` variable, in the `url`, and in the config). This simplifies the internal config by ensuring we only store each piece of config data in only one place.