### PR TITLE
Access config values out from stores

### DIFF
--- a/docs/api/store/aws.md
+++ b/docs/api/store/aws.md
@@ -1,6 +1,9 @@
 # AWS S3
 
 ::: obstore.store.S3Store
+::: obstore.store.S3ConfigInput
+    options:
+        show_if_no_docstring: true
 ::: obstore.store.S3Config
     options:
         show_if_no_docstring: true

--- a/docs/api/store/azure.md
+++ b/docs/api/store/azure.md
@@ -1,6 +1,9 @@
 # Microsoft Azure
 
 ::: obstore.store.AzureStore
+::: obstore.store.AzureConfigInput
+    options:
+        show_if_no_docstring: true
 ::: obstore.store.AzureConfig
     options:
         show_if_no_docstring: true

--- a/docs/api/store/gcs.md
+++ b/docs/api/store/gcs.md
@@ -1,6 +1,9 @@
 # Google Cloud Storage
 
 ::: obstore.store.GCSStore
+::: obstore.store.GCSConfigInput
+    options:
+        show_if_no_docstring: true
 ::: obstore.store.GCSConfig
     options:
         show_if_no_docstring: true

--- a/obstore/python/obstore/store/__init__.pyi
+++ b/obstore/python/obstore/store/__init__.pyi
@@ -20,28 +20,28 @@ from ._retry import RetryConfig as RetryConfig
 def from_url(
     url: str,
     *,
-    config: S3Config | None = None,
+    config: S3Config | S3ConfigInput | None = None,
     client_options: ClientConfig | None = None,
     retry_config: RetryConfig | None = None,
-    **kwargs: Unpack[S3Config],
+    **kwargs: Unpack[S3ConfigInput],
 ) -> ObjectStore: ...
 @overload
 def from_url(
     url: str,
     *,
-    config: GCSConfig | None = None,
+    config: GCSConfig | GCSConfigInput | None = None,
     client_options: ClientConfig | None = None,
     retry_config: RetryConfig | None = None,
-    **kwargs: Unpack[GCSConfig],
+    **kwargs: Unpack[GCSConfigInput],
 ) -> ObjectStore: ...
 @overload
 def from_url(
     url: str,
     *,
-    config: AzureConfig | None = None,
+    config: AzureConfig | AzureConfigInput | None = None,
     client_options: ClientConfig | None = None,
     retry_config: RetryConfig | None = None,
-    **kwargs: Unpack[AzureConfig],
+    **kwargs: Unpack[AzureConfigInput],
 ) -> ObjectStore: ...
 @overload
 def from_url(
@@ -56,7 +56,7 @@ def from_url(
 def from_url(
     url: str,
     *,
-    config: S3Config | GCSConfig | AzureConfig | None = None,
+    config: S3ConfigInput | GCSConfigInput | AzureConfigInput | None = None,
     client_options: ClientConfig | None = None,
     retry_config: RetryConfig | None = None,
     **kwargs: Any,

--- a/obstore/python/obstore/store/__init__.pyi
+++ b/obstore/python/obstore/store/__init__.pyi
@@ -3,11 +3,14 @@ from pathlib import Path
 from typing import Any, Unpack, overload
 
 from ._aws import S3Config as S3Config
+from ._aws import S3ConfigInput as S3ConfigInput
 from ._aws import S3Store as S3Store
 from ._azure import AzureConfig as AzureConfig
+from ._azure import AzureConfigInput as AzureConfigInput
 from ._azure import AzureStore as AzureStore
 from ._client import ClientConfig as ClientConfig
 from ._gcs import GCSConfig as GCSConfig
+from ._gcs import GCSConfigInput as GCSConfigInput
 from ._gcs import GCSStore as GCSStore
 from ._http import HTTPStore as HTTPStore
 from ._retry import BackoffConfig as BackoffConfig

--- a/obstore/python/obstore/store/__init__.pyi
+++ b/obstore/python/obstore/store/__init__.pyi
@@ -83,6 +83,10 @@ def from_url(
     - `amazonaws.com` -> [`S3Store`][obstore.store.S3Store]
     - `r2.cloudflarestorage.com` -> [`S3Store`][obstore.store.S3Store]
 
+    !!! note
+        For best static typing, use the constructors on individual store classes
+        directly.
+
     Args:
         url: well-known storage URL.
 

--- a/obstore/python/obstore/store/_aws.pyi
+++ b/obstore/python/obstore/store/_aws.pyi
@@ -11,12 +11,84 @@ from ._retry import RetryConfig
 # Note: we removed `bucket` because it overlaps with an existing named arg in the
 # constructors
 class S3Config(TypedDict, total=False):
-    """Configuration parameters for S3Store.
+    """Configuration parameters returned from [S3Store.config][obstore.store.S3Store.config].
 
-    There are duplicates of many parameters, and parameters can be either upper or lower
-    case. Not all parameters are required.
+    Note that this is a strict subset of the keys allowed for _input_ into the store,
+    see [S3ConfigInput][obstore.store.S3ConfigInput].
     """
 
+    aws_access_key_id: str
+    """AWS Access Key"""
+    aws_bucket: str
+    """Bucket name"""
+    aws_checksum_algorithm: str
+    """
+    Sets the [checksum algorithm] which has to be used for object integrity check during upload.
+
+    [checksum algorithm]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html
+    """
+    aws_conditional_put: str
+    """
+    See [`S3ConfigInput.aws_conditional_put`][obstore.store.S3ConfigInput.aws_conditional_put].
+    """
+    aws_container_credentials_relative_uri: str
+    """
+    See [`S3ConfigInput.aws_container_credentials_relative_uri`][obstore.store.S3ConfigInput.aws_container_credentials_relative_uri].
+    """
+    aws_copy_if_not_exists: str
+    """
+    See [`S3ConfigInput.aws_copy_if_not_exists`][obstore.store.S3ConfigInput.aws_copy_if_not_exists].
+    """
+    aws_default_region: str
+    """Default region"""
+    aws_disable_tagging: bool
+    """Disable tagging objects. This can be desirable if not supported by the backing store."""
+    aws_endpoint: str
+    """Sets custom endpoint for communicating with AWS S3."""
+    aws_imdsv1_fallback: str
+    """Fall back to ImdsV1"""
+    aws_metadata_endpoint: str
+    """Set the instance metadata endpoint"""
+    aws_region: str
+    """Region"""
+    aws_request_payer: bool
+    """If `True`, enable operations on requester-pays buckets."""
+    aws_s3_express: bool
+    """Enable Support for S3 Express One Zone"""
+    aws_secret_access_key: str
+    """Secret Access Key"""
+    aws_server_side_encryption: str
+    """
+    See [`S3ConfigInput.aws_server_side_encryption`][obstore.store.S3ConfigInput.aws_server_side_encryption].
+    """
+    aws_session_token: str
+    """Token to use for requests (passed to underlying provider)"""
+    aws_skip_signature: bool
+    """If `True`, S3Store will not fetch credentials and will not sign requests."""
+    aws_sse_bucket_key_enabled: bool
+    """
+    If set to `True`, will use the bucket's default KMS key for server-side encryption.
+    If set to `False`, will disable the use of the bucket's default KMS key for server-side encryption.
+    """
+    aws_sse_customer_key_base64: str
+    """
+    The base64 encoded, 256-bit customer encryption key to use for server-side
+    encryption. If set, the server side encryption config value must be `"sse-c"`.
+    """
+    aws_sse_kms_key_id: str
+    """
+    The KMS key ID to use for server-side encryption.
+
+    If set, the server side encryption config value must be `"aws:kms"` or `"aws:kms:dsse"`.
+    """
+    aws_token: str
+    """Token to use for requests (passed to underlying provider)"""
+    aws_unsigned_payload: bool
+    """Avoid computing payload checksum when calculating signature."""
+    aws_virtual_hosted_style_request: bool
+    """If virtual hosted style request has to be used."""
+
+class S3ConfigInput(TypedDict, total=False):
     access_key_id: str
     """AWS Access Key"""
     aws_access_key_id: str
@@ -152,6 +224,7 @@ class S3Config(TypedDict, total=False):
     """Avoid computing payload checksum when calculating signature."""
     aws_virtual_hosted_style_request: bool
     """If virtual hosted style request has to be used."""
+
     bucket_name: str
     """Bucket name"""
     checksum_algorithm: str
@@ -491,8 +564,8 @@ class S3Store:
 
     All constructors will check for environment variables. All environment variables
     starting with `AWS_` will be evaluated. Names must match keys from
-    [`S3Config`][obstore.store.S3Config]. Only upper-case environment variables are
-    accepted.
+    [`S3ConfigInput`][obstore.store.S3ConfigInput]. Only upper-case environment
+    variables are accepted.
 
     Some examples of variables extracted from environment:
 
@@ -522,10 +595,10 @@ class S3Store:
         bucket: str | None = None,
         *,
         prefix: str | None = None,
-        config: S3Config | None = None,
+        config: S3Config | S3ConfigInput | None = None,
         client_options: ClientConfig | None = None,
         retry_config: RetryConfig | None = None,
-        **kwargs: Unpack[S3Config],
+        **kwargs: Unpack[S3ConfigInput],
     ) -> None:
         """Create a new S3Store.
 
@@ -549,10 +622,10 @@ class S3Store:
         bucket: str | None = None,
         *,
         prefix: str | None = None,
-        config: S3Config | None = None,
+        config: S3Config | S3ConfigInput | None = None,
         client_options: ClientConfig | None = None,
         retry_config: RetryConfig | None = None,
-        **kwargs: Unpack[S3Config],
+        **kwargs: Unpack[S3ConfigInput],
     ) -> S3Store:
         """Construct a new S3Store with credentials inferred from a boto3 Session.
 
@@ -590,10 +663,10 @@ class S3Store:
         cls,
         url: str,
         *,
-        config: S3Config | None = None,
+        config: S3Config | S3ConfigInput | None = None,
         client_options: ClientConfig | None = None,
         retry_config: RetryConfig | None = None,
-        **kwargs: Unpack[S3Config],
+        **kwargs: Unpack[S3ConfigInput],
     ) -> S3Store:
         """Parse available connection info from a well-known storage URL.
 
@@ -620,3 +693,15 @@ class S3Store:
 
     def __getnewargs_ex__(self): ...
     def __repr__(self) -> str: ...
+    @property
+    def prefix(self) -> str | None:
+        """Get the prefix applied to all operations in this store, if any."""
+    @property
+    def config(self) -> S3Config:
+        """Get the underlying S3 config parameters."""
+    @property
+    def client_options(self) -> ClientConfig | None:
+        """Get the store's client configuration."""
+    @property
+    def retry_config(self) -> RetryConfig | None:
+        """Get the store's retry configuration."""

--- a/obstore/python/obstore/store/_azure.pyi
+++ b/obstore/python/obstore/store/_azure.pyi
@@ -3,7 +3,62 @@ from typing import TypedDict, Unpack
 from ._client import ClientConfig
 from ._retry import RetryConfig
 
+# TODO:
+# azure_storage_authority_host
+# azure_fabric_token_service_url
+# azure_fabric_workload_host
+# "azure_fabric_session_token",
+# "azure_fabric_cluster_identifier",
 class AzureConfig(TypedDict, total=False):
+    """Configuration parameters returned from [AzureStore.config][obstore.store.AzureStore.config].
+
+    Note that this is a strict subset of the keys allowed for _input_ into the store,
+    see [AzureConfigInput][obstore.store.AzureConfigInput].
+    """
+
+    azure_storage_account_name: str
+    """The name of the azure storage account"""
+    azure_storage_account_key: str
+    """Master key for accessing storage account"""
+    azure_storage_client_id: str
+    """Service principal client id for authorizing requests"""
+    azure_storage_client_secret: str
+    """Service principal client secret for authorizing requests"""
+    azure_storage_tenant_id: str
+    """Tenant id used in oauth flows"""
+    azure_storage_sas_key: str
+    """
+    Shared access signature.
+
+    The signature is expected to be percent-encoded, `much `like they are provided in
+    the azure storage explorer or azure portal.
+    """
+    azure_storage_token: str
+    """Bearer token"""
+    azure_storage_use_emulator: bool
+    """Use object store with azurite storage emulator"""
+    azure_use_fabric_endpoint: bool
+    """Use object store with url scheme account.dfs.fabric.microsoft.com"""
+    azure_storage_endpoint: str
+    """Override the endpoint used to communicate with blob storage"""
+    azure_msi_endpoint: str
+    """Endpoint to request a imds managed identity token"""
+    azure_object_id: str
+    """Object id for use with managed identity authentication"""
+    azure_msi_resource_id: str
+    """Msi resource id for use with managed identity authentication"""
+    azure_federated_token_file: str
+    """File containing token for Azure AD workload identity federation"""
+    azure_use_azure_cli: bool
+    """Use azure cli for acquiring access token"""
+    azure_skip_signature: bool
+    """Skip signing requests"""
+    azure_container_name: str
+    """Container name"""
+    azure_disable_tagging: bool
+    """Disables tagging objects"""
+
+class AzureConfigInput(TypedDict, total=False):
     """Configuration parameters for AzureStore.
 
     There are duplicates of many parameters, and parameters can be either upper or lower
@@ -282,7 +337,7 @@ class AzureStore:
         container: str | None = None,
         *,
         prefix: str | None = None,
-        config: AzureConfig | None = None,
+        config: AzureConfig | AzureConfigInput | None = None,
         client_options: ClientConfig | None = None,
         retry_config: RetryConfig | None = None,
         **kwargs: Unpack[AzureConfig],
@@ -307,7 +362,7 @@ class AzureStore:
         url: str,
         *,
         prefix: str | None = None,
-        config: AzureConfig | None = None,
+        config: AzureConfig | AzureConfigInput | None = None,
         client_options: ClientConfig | None = None,
         retry_config: RetryConfig | None = None,
         **kwargs: Unpack[AzureConfig],
@@ -344,3 +399,15 @@ class AzureStore:
 
     def __getnewargs_ex__(self): ...
     def __repr__(self) -> str: ...
+    @property
+    def prefix(self) -> str | None:
+        """Get the prefix applied to all operations in this store, if any."""
+    @property
+    def config(self) -> AzureConfig:
+        """Get the underlying Azure config parameters."""
+    @property
+    def client_options(self) -> ClientConfig | None:
+        """Get the store's client configuration."""
+    @property
+    def retry_config(self) -> RetryConfig | None:
+        """Get the store's retry configuration."""

--- a/obstore/python/obstore/store/_gcs.pyi
+++ b/obstore/python/obstore/store/_gcs.pyi
@@ -3,9 +3,30 @@ from typing import TypedDict, Unpack
 from ._client import ClientConfig
 from ._retry import RetryConfig
 
+class GCSConfig(TypedDict, total=False):
+    """Configuration parameters returned from [GCSStore.config][obstore.store.GCSStore.config].
+
+    Note that this is a strict subset of the keys allowed for _input_ into the store,
+    see [GCSConfigInput][obstore.store.GCSConfigInput].
+    """
+
+    google_service_account: str
+    """Path to the service account file."""
+
+    google_service_account_key: str
+    """The serialized service account key"""
+
+    google_bucket: str
+    """Bucket name."""
+
+    google_application_credentials: str
+    """Application credentials path.
+
+    See <https://cloud.google.com/docs/authentication/provide-credentials-adc>."""
+
 # Note: we removed `bucket` because it overlaps with an existing named arg in the
 # constructors
-class GCSConfig(TypedDict, total=False):
+class GCSConfigInput(TypedDict, total=False):
     """Configuration parameters for GCSStore.
 
     There are duplicates of many parameters, and parameters can be either upper or lower
@@ -86,7 +107,7 @@ class GCSStore:
         bucket: str | None = None,
         *,
         prefix: str | None = None,
-        config: GCSConfig | None = None,
+        config: GCSConfig | GCSConfigInput | None = None,
         client_options: ClientConfig | None = None,
         retry_config: RetryConfig | None = None,
         **kwargs: Unpack[GCSConfig],
@@ -111,7 +132,7 @@ class GCSStore:
         url: str,
         *,
         prefix: str | None = None,
-        config: GCSConfig | None = None,
+        config: GCSConfig | GCSConfigInput | None = None,
         client_options: ClientConfig | None = None,
         retry_config: RetryConfig | None = None,
         **kwargs: Unpack[GCSConfig],
@@ -136,3 +157,15 @@ class GCSStore:
 
     def __getnewargs_ex__(self): ...
     def __repr__(self) -> str: ...
+    @property
+    def prefix(self) -> str | None:
+        """Get the prefix applied to all operations in this store, if any."""
+    @property
+    def config(self) -> GCSConfig:
+        """Get the underlying GCS config parameters."""
+    @property
+    def client_options(self) -> ClientConfig | None:
+        """Get the store's client configuration."""
+    @property
+    def retry_config(self) -> RetryConfig | None:
+        """Get the store's retry configuration."""

--- a/obstore/python/obstore/store/_http.pyi
+++ b/obstore/python/obstore/store/_http.pyi
@@ -56,3 +56,12 @@ class HTTPStore:
 
     def __getnewargs_ex__(self): ...
     def __repr__(self) -> str: ...
+    @property
+    def url(self) -> str:
+        """Get the base url of this store."""
+    @property
+    def client_options(self) -> ClientConfig | None:
+        """Get the store's client configuration."""
+    @property
+    def retry_config(self) -> RetryConfig | None:
+        """Get the store's retry configuration."""

--- a/pyo3-object_store/src/aws.rs
+++ b/pyo3-object_store/src/aws.rs
@@ -247,6 +247,26 @@ impl PyS3Store {
             format!("S3Store(bucket=\"{}\")", bucket)
         }
     }
+
+    #[getter]
+    fn prefix(&self) -> Option<&PyPath> {
+        self.config.prefix.as_ref()
+    }
+
+    #[getter]
+    fn config(&self) -> PyAmazonS3Config {
+        self.config.config.clone()
+    }
+
+    #[getter]
+    fn client_options(&self) -> Option<PyClientOptions> {
+        self.config.client_options.clone()
+    }
+
+    #[getter]
+    fn retry_config(&self) -> Option<PyRetryConfig> {
+        self.config.retry_config.clone()
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/pyo3-object_store/src/azure.rs
+++ b/pyo3-object_store/src/azure.rs
@@ -170,6 +170,26 @@ impl PyAzureStore {
             format!("AzureStore(container=\"{}\")", container_name)
         }
     }
+
+    #[getter]
+    fn prefix(&self) -> Option<&PyPath> {
+        self.config.prefix.as_ref()
+    }
+
+    #[getter]
+    fn config(&self) -> PyAzureConfig {
+        self.config.config.clone()
+    }
+
+    #[getter]
+    fn client_options(&self) -> Option<PyClientOptions> {
+        self.config.client_options.clone()
+    }
+
+    #[getter]
+    fn retry_config(&self) -> Option<PyRetryConfig> {
+        self.config.retry_config.clone()
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/pyo3-object_store/src/gcp.rs
+++ b/pyo3-object_store/src/gcp.rs
@@ -168,6 +168,26 @@ impl PyGCSStore {
             format!("GCSStore(bucket=\"{}\")", bucket)
         }
     }
+
+    #[getter]
+    fn prefix(&self) -> Option<&PyPath> {
+        self.config.prefix.as_ref()
+    }
+
+    #[getter]
+    fn config(&self) -> PyGoogleConfig {
+        self.config.config.clone()
+    }
+
+    #[getter]
+    fn client_options(&self) -> Option<PyClientOptions> {
+        self.config.client_options.clone()
+    }
+
+    #[getter]
+    fn retry_config(&self) -> Option<PyRetryConfig> {
+        self.config.retry_config.clone()
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/pyo3-object_store/src/http.rs
+++ b/pyo3-object_store/src/http.rs
@@ -98,4 +98,19 @@ impl PyHttpStore {
     fn __repr__(&self) -> String {
         format!("HTTPStore(\"{}\")", &self.config.url.as_ref())
     }
+
+    #[getter]
+    fn url(&self) -> &PyUrl {
+        &self.config.url
+    }
+
+    #[getter]
+    fn client_options(&self) -> Option<PyClientOptions> {
+        self.config.client_options.clone()
+    }
+
+    #[getter]
+    fn retry_config(&self) -> Option<PyRetryConfig> {
+        self.config.retry_config.clone()
+    }
 }

--- a/pyo3-object_store/src/local.rs
+++ b/pyo3-object_store/src/local.rs
@@ -111,4 +111,9 @@ impl PyLocalStore {
             "LocalStore".to_string()
         }
     }
+
+    #[getter]
+    fn prefix(&self) -> Option<&std::path::PathBuf> {
+        self.config.prefix.as_ref()
+    }
 }

--- a/pyo3-object_store/src/path.rs
+++ b/pyo3-object_store/src/path.rs
@@ -21,6 +21,16 @@ impl<'py> IntoPyObject<'py> for PyPath {
     }
 }
 
+impl<'py> IntoPyObject<'py> for &PyPath {
+    type Target = PyString;
+    type Output = Bound<'py, PyString>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        Ok(PyString::new(py, self.0.as_ref()))
+    }
+}
+
 impl AsRef<Path> for PyPath {
     fn as_ref(&self) -> &Path {
         &self.0

--- a/pyo3-object_store/src/url.rs
+++ b/pyo3-object_store/src/url.rs
@@ -35,7 +35,17 @@ impl<'py> IntoPyObject<'py> for PyUrl {
     type Error = std::convert::Infallible;
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        String::from(self.0).into_pyobject(py)
+        Ok(PyString::new(py, self.0.as_str()))
+    }
+}
+
+impl<'py> IntoPyObject<'py> for &PyUrl {
+    type Target = PyString;
+    type Output = Bound<'py, PyString>;
+    type Error = std::convert::Infallible;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        Ok(PyString::new(py, self.0.as_str()))
     }
 }
 

--- a/tests/store/test_s3.py
+++ b/tests/store/test_s3.py
@@ -55,3 +55,21 @@ def test_pickle():
     )
     restored = pickle.loads(pickle.dumps(store))
     _objects = next(obs.list(restored))
+
+
+def test_config_round_trip():
+    store = S3Store.from_url(
+        "s3://ookla-open-data/parquet/performance/type=fixed/year=2024/quarter=1",
+        region="us-west-2",
+        skip_signature=True,
+    )
+    new_store = S3Store(
+        config=store.config,
+        prefix=store.prefix,
+        client_options=store.client_options,
+        retry_config=store.retry_config,
+    )
+    assert store.config == new_store.config
+    assert store.prefix == new_store.prefix
+    assert store.client_options == new_store.client_options
+    assert store.retry_config == new_store.retry_config


### PR DESCRIPTION
Now that we've merged https://github.com/developmentseed/obstore/pull/209, this is much simpler to do, because **all configuration** is stored in at most four places:

- prefix
- store-specific config
- client config
- retry config

The most annoying part of this PR is that the configuration parameters _returned_ are a strict subset of the allowed _input_ for config parameters. And the python type system apparently doesn't allow the _narrower_ typed dict to be passed directly to a function that accepts the _broader_ typed dict. So it's a bit verbose, but at least the typing works.

Closes #191 