### PR TITLE
Check for forked process when accessing tokio runtime

### DIFF
--- a/pyo3-object_store/src/runtime.rs
+++ b/pyo3-object_store/src/runtime.rs
@@ -6,6 +6,7 @@ use pyo3::sync::GILOnceCell;
 use tokio::runtime::Runtime;
 
 static RUNTIME: GILOnceCell<Arc<Runtime>> = GILOnceCell::new();
+static PID: GILOnceCell<u32> = GILOnceCell::new();
 
 /// Construct a tokio runtime for sync requests
 ///
@@ -18,6 +19,18 @@ static RUNTIME: GILOnceCell<Arc<Runtime>> = GILOnceCell::new();
 /// Downstream consumers may explicitly want to depend on tokio and add `rt-multi-thread` as a
 /// tokio feature flag to opt-in to the multi-threaded tokio runtime.
 pub fn get_runtime(py: Python<'_>) -> PyResult<Arc<Runtime>> {
+    let pid = std::process::id();
+    let runtime_pid = *PID.get_or_init(py, || pid);
+    if pid != runtime_pid {
+        panic!(
+            "Forked process detected - current PID is {} but the tokio runtime was created by {}. The tokio \
+            runtime does not support forked processes https://github.com/tokio-rs/tokio/issues/4301. If you are \
+            seeing this message while using Python multithreading make sure to use the `spawn` or `forkserver` \
+            mode.",
+            pid, runtime_pid
+        );
+    }
+
     let runtime = RUNTIME.get_or_try_init(py, || {
         Ok::<_, PyErr>(Arc::new(Runtime::new().map_err(|err| {
             PyValueError::new_err(format!("Could not create tokio runtime. {}", err))


### PR DESCRIPTION
Ref https://github.com/developmentseed/obstore/pull/203#discussion_r1940057514

Also removes an unnecessary `Arc` around the runtime