### PR TITLE
Use manylinux 2_24 for aarch64 linux wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -32,7 +32,7 @@ jobs:
             manylinux: auto
           - runner: ubuntu-latest
             target: aarch64
-            manylinux: "2_28"
+            manylinux: "2_24"
           - runner: ubuntu-latest
             target: armv7
             manylinux: auto


### PR DESCRIPTION
Manylinux `2_28` is a newer linux standard than `2_24`, so `2_24` is more broadly compatible, and we should use it if possible. We have to increase the version above `auto` because of our use of `ring`. 

See the following for more information: https://github.com/kylebarron/arro3/pull/279, https://github.com/PyO3/maturin-action/issues/278#issuecomment-2555576928, https://github.com/kylebarron/arro3/pull/277, https://github.com/developmentseed/obstore/pull/111 (original arro3 issue: https://github.com/kylebarron/arro3/issues/276).

Ran a wheel build manually to double check this works:
https://github.com/developmentseed/obstore/actions/runs/13166875454

Apparently `2_24` [is deprecated](https://github.com/PyO3/maturin-action/blob/cb02947ed4734e30926f550f075b2c136c2e2ad8/README.md#manylinux-docker-container) (at least the maturin-action container) 🤷‍♂️ . We'll use it until it goes away 😄 