### PR TITLE
try wheel build with manylinux auto

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -32,7 +32,7 @@ jobs:
             manylinux: auto
           - runner: ubuntu-latest
             target: aarch64
-            manylinux: "2_28"
+            manylinux: auto
           - runner: ubuntu-latest
             target: armv7
             manylinux: auto


### PR DESCRIPTION
Counterpart to #225 

In the [log output](https://github.com/developmentseed/obstore/actions/runs/13166875454/job/36749019999) of #225, I see 

> 📦 Wheel is eligible for a higher priority tag. You requested manylinux_2_24 but this wheel is eligible for manylinux_2_17 (aka manylinux2014)

I think setting `manylinux: auto` in CI will fail because of our `ring` dependency, but let's double check.

Let's test this on CI: https://github.com/developmentseed/obstore/actions/runs/13167021669/job/36749471672