### PR TITLE
Repro for: returning `()` creates Python tuple, not `None`

### DIFF
--- a/obstore/src/copy.rs
+++ b/obstore/src/copy.rs
@@ -2,6 +2,8 @@ use object_store::ObjectStore;
 use pyo3::prelude::*;
 use pyo3_object_store::{get_runtime, PyObjectStore, PyObjectStoreError, PyObjectStoreResult};
 
+use crate::utils::PyNone;
+
 #[pyfunction]
 #[pyo3(signature = (store, from_, to, *, overwrite=true))]
 pub(crate) fn copy(
@@ -43,6 +45,6 @@ pub(crate) fn copy_async(
             store.as_ref().copy_if_not_exists(&from_, &to)
         };
         fut.await.map_err(PyObjectStoreError::ObjectStoreError)?;
-        Ok(())
+        Ok(PyNone)
     })
 }

--- a/obstore/src/delete.rs
+++ b/obstore/src/delete.rs
@@ -3,6 +3,7 @@ use pyo3::prelude::*;
 use pyo3_object_store::{get_runtime, PyObjectStore, PyObjectStoreError, PyObjectStoreResult};
 
 use crate::path::PyPaths;
+use crate::utils::PyNone;
 
 #[pyfunction]
 pub(crate) fn delete(py: Python, store: PyObjectStore, paths: PyPaths) -> PyObjectStoreResult<()> {
@@ -49,6 +50,6 @@ pub(crate) fn delete_async(
                     .map_err(PyObjectStoreError::ObjectStoreError)?;
             }
         }
-        Ok(())
+        Ok(PyNone)
     })
 }

--- a/obstore/src/lib.rs
+++ b/obstore/src/lib.rs
@@ -13,6 +13,7 @@ mod put;
 mod rename;
 mod signer;
 mod tags;
+mod utils;
 
 use pyo3::prelude::*;
 

--- a/obstore/src/lib.rs
+++ b/obstore/src/lib.rs
@@ -44,10 +44,17 @@ fn check_debug_build(_py: Python) -> PyResult<()> {
     Ok(())
 }
 
+#[pyfunction]
+pub(crate) fn return_none_async(py: Python) -> PyResult<Bound<PyAny>> {
+    pyo3_async_runtimes::tokio::future_into_py(py, async move { Ok(()) })
+}
+
 /// A Python module implemented in Rust.
 #[pymodule]
 fn _obstore(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     check_debug_build(py)?;
+
+    m.add_wrapped(wrap_pyfunction!(return_none_async))?;
 
     m.add_wrapped(wrap_pyfunction!(___version))?;
 

--- a/obstore/src/rename.rs
+++ b/obstore/src/rename.rs
@@ -2,6 +2,8 @@ use object_store::ObjectStore;
 use pyo3::prelude::*;
 use pyo3_object_store::{get_runtime, PyObjectStore, PyObjectStoreError, PyObjectStoreResult};
 
+use crate::utils::PyNone;
+
 #[pyfunction]
 #[pyo3(signature = (store, from_, to, *, overwrite=true))]
 pub(crate) fn rename(
@@ -43,6 +45,6 @@ pub(crate) fn rename_async(
             store.as_ref().rename_if_not_exists(&from_, &to)
         };
         fut.await.map_err(PyObjectStoreError::ObjectStoreError)?;
-        Ok(())
+        Ok(PyNone)
     })
 }

--- a/obstore/src/utils.rs
+++ b/obstore/src/utils.rs
@@ -1,0 +1,15 @@
+use pyo3::prelude::*;
+
+/// Returning `()` from `future_into_py` returns an empty tuple instead of None
+/// https://github.com/developmentseed/obstore/issues/240
+pub(crate) struct PyNone;
+
+impl<'py> IntoPyObject<'py> for PyNone {
+    type Target = PyAny;
+    type Output = Bound<'py, PyAny>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        Ok(py.None().bind(py).clone())
+    }
+}

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -20,6 +20,15 @@ def test_delete_one():
     assert len(obs.list(store).collect()) == 0
 
 
+@pytest.mark.asyncio
+async def test_delete_async():
+    store = MemoryStore()
+
+    await obs.put_async(store, "file1.txt", b"foo")
+    result = await obs.delete_async(store, "file1.txt")
+    assert result is None
+
+
 def test_delete_many():
     store = MemoryStore()
 


### PR DESCRIPTION
```
uv run maturin develop -m obstore/Cargo.toml
uv run ipython
```

<img width="370" alt="image" src="https://github.com/user-attachments/assets/6723b83a-cb40-480b-95b1-42309d7d1c49" />
