### PR TITLE
Print full error message for GenericError

### DIFF
--- a/pyo3-object_store/src/error.rs
+++ b/pyo3-object_store/src/error.rs
@@ -111,7 +111,7 @@ impl From<PyObjectStoreError> for PyErr {
                 object_store::Error::Generic {
                     store: _,
                     source: _,
-                } => GenericError::new_err(format!("{err:#?}")),
+                } => GenericError::new_err(err.to_string()),
                 object_store::Error::NotFound { path: _, source: _ } => {
                     PyFileNotFoundError::new_err(format!("{err:#?}"))
                 }
@@ -145,7 +145,7 @@ impl From<PyObjectStoreError> for PyErr {
                 object_store::Error::UnknownConfigurationKey { store: _, key: _ } => {
                     UnknownConfigurationKeyError::new_err(format!("{err:#?}"))
                 }
-                _ => GenericError::new_err(format!("{err:#?}")),
+                _ => GenericError::new_err(err.to_string()),
             },
             PyObjectStoreError::IOError(err) => PyIOError::new_err(format!("{err:#?}")),
         }


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Make BareRedirect error message more informative

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Change `format!("{err:#?}")` to `err.to_string()`

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Run `uv run maturin develop -m obstore/Cargo.toml`, and then try opening some file object that requires setting AWS_REGION

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
- Resolves #169
