### PR TITLE
Dynamically set the value of `__module__`

### DIFF
--- a/obstore/python/obstore/_list.pyi
+++ b/obstore/python/obstore/_list.pyi
@@ -48,7 +48,7 @@ class ListResult(TypedDict, Generic[ListChunkType]):
     """Object metadata for the listing"""
 
 ListChunkType = TypeVar("ListChunkType", List[ObjectMeta], RecordBatch, Table)  # noqa: PYI001
-"""The data structure used for holding
+"""The data structure used for holding list results.
 
 By default, listing APIs return a `list` of [`ObjectMeta`][obstore.ObjectMeta]. However
 for improved performance when listing large buckets, you can pass `return_arrow=True`.

--- a/pyo3-object_store/src/api.rs
+++ b/pyo3-object_store/src/api.rs
@@ -125,6 +125,46 @@ pub fn register_exceptions_module(
         py.get_type::<UnknownConfigurationKeyError>(),
     )?;
 
+    // Set the value of `__module__` correctly on each publicly exposed function or class
+    let __module__ = intern!(py, "__module__");
+    child_module
+        .getattr("BaseError")?
+        .setattr(__module__, &full_module_string)?;
+    child_module
+        .getattr("GenericError")?
+        .setattr(__module__, &full_module_string)?;
+    child_module
+        .getattr("NotFoundError")?
+        .setattr(__module__, &full_module_string)?;
+    child_module
+        .getattr("InvalidPathError")?
+        .setattr(__module__, &full_module_string)?;
+    child_module
+        .getattr("JoinError")?
+        .setattr(__module__, &full_module_string)?;
+    child_module
+        .getattr("NotSupportedError")?
+        .setattr(__module__, &full_module_string)?;
+    child_module
+        .getattr("AlreadyExistsError")?
+        .setattr(__module__, &full_module_string)?;
+    child_module
+        .getattr("PreconditionError")?
+        .setattr(__module__, &full_module_string)?;
+    child_module
+        .getattr("NotModifiedError")?
+        .setattr(__module__, &full_module_string)?;
+    child_module
+        .getattr("PermissionDeniedError")?
+        .setattr(__module__, &full_module_string)?;
+    child_module
+        .getattr("UnauthenticatedError")?
+        .setattr(__module__, &full_module_string)?;
+    child_module
+        .getattr("UnknownConfigurationKeyError")?
+        .setattr(__module__, &full_module_string)?;
+
+    // Add the child module to the parent module
     parent_module.add_submodule(&child_module)?;
 
     py.import(intern!(py, "sys"))?

--- a/pyo3-object_store/src/api.rs
+++ b/pyo3-object_store/src/api.rs
@@ -54,11 +54,36 @@ pub fn register_store_module(
     child_module.add_class::<PyMemoryStore>()?;
     child_module.add_class::<PyS3Store>()?;
 
+    // Set the value of `__module__` correctly on each publicly exposed function or class
+    let __module__ = intern!(py, "__module__");
+    child_module
+        .getattr("from_url")?
+        .setattr(__module__, &full_module_string)?;
+    child_module
+        .getattr("AzureStore")?
+        .setattr(__module__, &full_module_string)?;
+    child_module
+        .getattr("GCSStore")?
+        .setattr(__module__, &full_module_string)?;
+    child_module
+        .getattr("HTTPStore")?
+        .setattr(__module__, &full_module_string)?;
+    child_module
+        .getattr("LocalStore")?
+        .setattr(__module__, &full_module_string)?;
+    child_module
+        .getattr("MemoryStore")?
+        .setattr(__module__, &full_module_string)?;
+    child_module
+        .getattr("S3Store")?
+        .setattr(__module__, &full_module_string)?;
+
+    // Add the child module to the parent module
     parent_module.add_submodule(&child_module)?;
 
     py.import(intern!(py, "sys"))?
         .getattr(intern!(py, "modules"))?
-        .set_item(full_module_string.as_str(), &child_module)?;
+        .set_item(&full_module_string, &child_module)?;
 
     // needs to be set *after* `add_submodule()`
     child_module.setattr("__name__", full_module_string)?;

--- a/pyo3-object_store/src/aws/store.rs
+++ b/pyo3-object_store/src/aws/store.rs
@@ -63,7 +63,7 @@ impl S3Config {
 }
 
 /// A Python-facing wrapper around an [`AmazonS3`].
-#[pyclass(name = "S3Store", module = "obstore.store", frozen)]
+#[pyclass(name = "S3Store", frozen)]
 pub struct PyS3Store {
     store: Arc<MaybePrefixedStore<AmazonS3>>,
     /// A config used for pickling. This must stay in sync with the underlying store's config.

--- a/pyo3-object_store/src/azure.rs
+++ b/pyo3-object_store/src/azure.rs
@@ -52,7 +52,7 @@ impl AzureConfig {
 }
 
 /// A Python-facing wrapper around a [`MicrosoftAzure`].
-#[pyclass(name = "AzureStore", module = "obstore.store", frozen)]
+#[pyclass(name = "AzureStore", frozen)]
 pub struct PyAzureStore {
     store: Arc<MaybePrefixedStore<MicrosoftAzure>>,
     /// A config used for pickling. This must stay in sync with the underlying store's config.

--- a/pyo3-object_store/src/gcp.rs
+++ b/pyo3-object_store/src/gcp.rs
@@ -52,7 +52,7 @@ impl GCSConfig {
 }
 
 /// A Python-facing wrapper around a [`GoogleCloudStorage`].
-#[pyclass(name = "GCSStore", module = "obstore.store", frozen)]
+#[pyclass(name = "GCSStore", frozen)]
 pub struct PyGCSStore {
     store: Arc<MaybePrefixedStore<GoogleCloudStorage>>,
     /// A config used for pickling. This must stay in sync with the underlying store's config.

--- a/pyo3-object_store/src/http.rs
+++ b/pyo3-object_store/src/http.rs
@@ -32,7 +32,7 @@ impl HTTPConfig {
 }
 
 /// A Python-facing wrapper around a [`HttpStore`].
-#[pyclass(name = "HTTPStore", module = "obstore.store", frozen)]
+#[pyclass(name = "HTTPStore", frozen)]
 pub struct PyHttpStore {
     // Note: we don't need to wrap this in a MaybePrefixedStore because the HttpStore manages its
     // own prefix.

--- a/pyo3-object_store/src/local.rs
+++ b/pyo3-object_store/src/local.rs
@@ -29,7 +29,7 @@ impl LocalConfig {
 }
 
 /// A Python-facing wrapper around a [`LocalFileSystem`].
-#[pyclass(name = "LocalStore", module = "obstore.store", frozen)]
+#[pyclass(name = "LocalStore", frozen)]
 pub struct PyLocalStore {
     store: Arc<LocalFileSystem>,
     config: LocalConfig,


### PR DESCRIPTION
### Change list

- Set `__module__` on exported functions and classes, dynamically instead of via the `module = ""` flag in the `#[pyclass]` macro.

This allows for accurate pickling, even when pyo3-object_store is used outside of `obstore`