### PR TITLE
Update get_ranges coalesce doc

### DIFF
--- a/obstore/python/obstore/_get.pyi
+++ b/obstore/python/obstore/_get.pyi
@@ -327,7 +327,7 @@ def get_ranges(
 
     To improve performance this will:
 
-    - Combine ranges less than 10MB apart into a single call to `fetch`
+    - Transparently combine ranges less than 1MB apart into a single underlying request
     - Make multiple `fetch` requests in parallel (up to maximum of 10)
 
     Args:


### PR DESCRIPTION
The default coalesce size is 1MB, not 10MB https://docs.rs/object_store/latest/object_store/constant.OBJECT_STORE_COALESCE_DEFAULT.html