### PR TITLE
fsspec: Allow calling `register` with no arguments

### DIFF
--- a/obstore/python/obstore/fsspec.py
+++ b/obstore/python/obstore/fsspec.py
@@ -65,7 +65,7 @@ if TYPE_CHECKING:
         S3ConfigInput,
     )
 
-SUPPORTED_PROTOCOLS = {
+SUPPORTED_PROTOCOLS: set[str] = {
     "abfs",
     "abfss",
     "adl",
@@ -80,6 +80,7 @@ SUPPORTED_PROTOCOLS = {
     "s3",
     "s3a",
 }
+"""All supported protocols."""
 
 
 class FsspecStore(fsspec.asyn.AsyncFileSystem):
@@ -747,7 +748,11 @@ class BufferedFile(fsspec.spec.AbstractBufferedFile):
             raise ValueError("Cannot set `.loc`. Use `seek` instead.")
 
 
-def register(protocol: str | Iterable[str], *, asynchronous: bool = False) -> None:
+def register(
+    protocol: str | Iterable[str] | None = None,
+    *,
+    asynchronous: bool = False,
+) -> None:
     """Dynamically register a subclass of FsspecStore for the given protocol(s).
 
     This function creates a new subclass of FsspecStore with the specified
@@ -755,13 +760,16 @@ def register(protocol: str | Iterable[str], *, asynchronous: bool = False) -> No
     the function registers each one individually.
 
     Args:
-        protocol (str | list[str]): A single protocol (e.g., "s3", "gcs", "abfs") or
-            a list of protocols to register FsspecStore for.
-        asynchronous (bool, optional): If True, the registered store will support
-            asynchronous operations. Defaults to False.
+        protocol: A single protocol (e.g., "s3", "gcs", "abfs") or
+            a list of protocols to register FsspecStore for. Defaults to `None`, which
+            will register `obstore` as the provider for all [supported
+            protocols][obstore.fsspec.SUPPORTED_PROTOCOLS].
+        asynchronous: If `True`, the registered store will support
+            asynchronous operations. Defaults to `False`.
 
     Example:
     ```py
+    register() # Register all supported protocols
     register("s3")
     register("s3", asynchronous=True)  # Registers an async store for "s3"
     register(["gcs", "abfs"])  # Registers both "gcs" and "abfs"
@@ -773,6 +781,9 @@ def register(protocol: str | Iterable[str], *, asynchronous: bool = False) -> No
           FsspecStore class.
 
     """
+    if protocol is None:
+        protocol = SUPPORTED_PROTOCOLS
+
     if isinstance(protocol, str):
         _register(protocol, asynchronous=asynchronous)
         return


### PR DESCRIPTION
Registers obstore as the default handler for all supported protocols, except `file://` and `memory://`