### PR TITLE
Update etag conditional put docs

### DIFF
--- a/obstore/python/obstore/store/_aws.pyi
+++ b/obstore/python/obstore/store/_aws.pyi
@@ -195,7 +195,7 @@ class S3ConfigInput(TypedDict, total=False):
 
     Supported values:
 
-    - `"etag"`: Supported for S3-compatible stores that support conditional
+    - `"etag"` (default): Supported for S3-compatible stores that support conditional
         put using the standard [HTTP precondition] headers `If-Match` and
         `If-None-Match`.
 
@@ -325,7 +325,7 @@ class S3ConfigInput(TypedDict, total=False):
 
     Supported values:
 
-    - `"etag"`: Supported for S3-compatible stores that support conditional
+    - `"etag"` (default): Supported for S3-compatible stores that support conditional
         put using the standard [HTTP precondition] headers `If-Match` and
         `If-None-Match`.
 
@@ -429,7 +429,7 @@ class S3ConfigInput(TypedDict, total=False):
 
     Supported values:
 
-    - `"etag"`: Supported for S3-compatible stores that support conditional
+    - `"etag"` (default): Supported for S3-compatible stores that support conditional
         put using the standard [HTTP precondition] headers `If-Match` and
         `If-None-Match`.
 
@@ -560,7 +560,7 @@ class S3ConfigInput(TypedDict, total=False):
 
     Supported values:
 
-    - `"etag"`: Supported for S3-compatible stores that support conditional
+    - `"etag"` (default): Supported for S3-compatible stores that support conditional
         put using the standard [HTTP precondition] headers `If-Match` and
         `If-None-Match`.
 


### PR DESCRIPTION
In https://github.com/developmentseed/obstore/pull/308 we updated to the 0.12 latest main (release candidate). It's now the default value for using AWS conditional put.

Closes https://github.com/developmentseed/obstore/issues/221, closes https://github.com/developmentseed/obstore/issues/281.