### PR TITLE
Update griffe

### DIFF
--- a/docs/fsspec.md
+++ b/docs/fsspec.md
@@ -69,7 +69,6 @@ fs = fsspec.filesystem("https")
 content = fs.cat_file("https://example.com/")
 
 # Or, open the file directly
-```py
 url = "https://github.com/opengeospatial/geoparquet/raw/refs/heads/main/examples/example.parquet"
 with fsspec.open(url) as file:
     content = file.read()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,7 +64,7 @@ nav:
       - api/attributes.md
       - api/exceptions.md
       - api/file.md
-      - fsspec Integration: api/fsspec.md
+      - obstore.fsspec: api/fsspec.md
   - Advanced Topics:
       - advanced/pickle.md
   - Developer Docs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dev-dependencies = [
     "arro3-core>=0.4.2",
     "boto3>=1.35.38",
     "fsspec>=2024.10.0",
+    "griffe>=1.6.0",
     "griffe-inherited-docstrings>=1.0.1",
     "ipykernel>=6.29.5",
     "maturin>=1.7.4",

--- a/uv.lock
+++ b/uv.lock
@@ -529,14 +529,14 @@ wheels = [
 
 [[package]]
 name = "griffe"
-version = "1.5.4"
+version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/9b/0bc9d53ed6628aae43223dd3c081637da54f66ed17a8c1d9fd36ee5da244/griffe-1.5.4.tar.gz", hash = "sha256:073e78ad3e10c8378c2f798bd4ef87b92d8411e9916e157fd366a17cc4fd4e52", size = 389376 }
+sdist = { url = "https://files.pythonhosted.org/packages/a0/1a/d467b93f5e0ea4edf3c1caef44cfdd53a4a498cb3a6bb722df4dd0fdd66a/griffe-1.6.0.tar.gz", hash = "sha256:eb5758088b9c73ad61c7ac014f3cdfb4c57b5c2fcbfca69996584b702aefa354", size = 391819 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/29/d0f156c076ec71eb485e70cbcde4872e3c045cda965a48d1d938aa3d9f76/griffe-1.5.4-py3-none-any.whl", hash = "sha256:ed33af890586a5bebc842fcb919fc694b3dc1bc55b7d9e0228de41ce566b4a1d", size = 128102 },
+    { url = "https://files.pythonhosted.org/packages/bf/02/5a22bc98d0aebb68c15ba70d2da1c84a5ef56048d79634e5f96cd2ba96e9/griffe-1.6.0-py3-none-any.whl", hash = "sha256:9f1dfe035d4715a244ed2050dfbceb05b1f470809ed4f6bb10ece5a7302f8dd1", size = 128470 },
 ]
 
 [[package]]
@@ -1998,6 +1998,7 @@ dev = [
     { name = "arro3-core" },
     { name = "boto3" },
     { name = "fsspec" },
+    { name = "griffe" },
     { name = "griffe-inherited-docstrings" },
     { name = "ipykernel" },
     { name = "maturin" },
@@ -2023,6 +2024,7 @@ dev = [
     { name = "arro3-core", specifier = ">=0.4.2" },
     { name = "boto3", specifier = ">=1.35.38" },
     { name = "fsspec", specifier = ">=2024.10.0" },
+    { name = "griffe", specifier = ">=1.6.0" },
     { name = "griffe-inherited-docstrings", specifier = ">=1.0.1" },
     { name = "ipykernel", specifier = ">=6.29.5" },
     { name = "maturin", specifier = ">=1.7.4" },


### PR DESCRIPTION
Ensures that the symlink for `bytes.pyi` works: https://github.com/mkdocstrings/python/issues/258