### PR TITLE
Bump bytes dependency to avoid memory leak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,9 +359,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "camino"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ categories = []
 rust-version = "1.75"
 
 [workspace.dependencies]
-bytes = "1.7.0"
+bytes = "1.10.1"
 chrono = "0.4.38"
 futures = "0.3.31"
 http = "1.2"

--- a/pyo3-bytes/Cargo.toml
+++ b/pyo3-bytes/Cargo.toml
@@ -15,7 +15,8 @@ categories = []
 rust-version = "1.75"
 
 [dependencies]
-bytes = "1.9"
+# https://github.com/tokio-rs/bytes/releases/tag/v1.10.1
+bytes = "1.10.1"
 pyo3 = "0.23.4"
 
 [lib]


### PR DESCRIPTION
Ref https://github.com/tokio-rs/bytes/releases/tag/v1.10.1