### PR TITLE
Revert defaulting `use_azure_cli` to `True`

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -44,7 +44,7 @@ Note that many authentication variants are already supported natively.
 - Workload identity OAuth2, using a `client_id`, `tenant_id`, and `federated_token_file` passed in by the user
 - OAuth2, using a `client_id`, `client_secret`, and `tenant_id` passed in by the user
 - A SAS key passed in by the user.
-- Azure CLI. (If you want to ensure the IMDS authentication is used below, pass [`use_azure_cli=False`][obstore.store.AzureConfig.use_azure_cli] to `AzureStore`.)
+- Azure CLI. (When constructing `AzureStore` you must set [`use_azure_cli`][obstore.store.AzureConfig.use_azure_cli] to `True`, either by passing `use_azure_cli=True` or by setting the `AZURE_USE_AZURE_CLI` environment variable to `"TRUE"`).
 - IMDS Managed Identity Provider.
 
 (A transcription of [this underlying code](https://github.com/apache/arrow-rs/blob/a00f9f43a0530b9255e4f9940e43121deedb0cc7/object_store/src/azure/builder.rs#L942-L1019)).

--- a/docs/dev/overridden-defaults.md
+++ b/docs/dev/overridden-defaults.md
@@ -4,12 +4,4 @@ In general, we wish to follow the upstream `object_store` as closely as possible
 
 However, there are occasionally places where we want to diverge from the upstream decision making, and we document those here.
 
-## Azure CLI
-
-We always check for Azure CLI authentication as a fallback.
-
-If we stuck with the upstream `object_store` default, you would need to pass `use_azure_cli=True` to check for Azure CLI credentials.
-
-The Azure CLI is the [second-to-last Azure authentication method checked](https://github.com/apache/arrow-rs/blob/9c92a50b6d190ca9d0c74c3ccc69e348393d9246/object_store/src/azure/builder.rs#L1015-L1016) checked. So this only changes the default behavior for people relying on instance authentication. For those people, they can still pass `use_azure_cli=False`.
-
-See upstream discussion [here](https://github.com/apache/arrow-rs/issues/7204).
+(Currently none).

--- a/obstore/python/obstore/store/_azure.pyi
+++ b/obstore/python/obstore/store/_azure.pyi
@@ -150,8 +150,6 @@ class AzureConfig(TypedDict, total=False):
     use_azure_cli: bool
     """Set if the Azure Cli should be used for acquiring access token.
 
-    Defaults to `True` (as a fallback).
-
     <https://learn.microsoft.com/en-us/cli/azure/account?view=azure-cli-latest#az-account-get-access-token>.
 
     **Environment variable**: `AZURE_USE_AZURE_CLI`.

--- a/pyo3-object_store/src/azure/store.rs
+++ b/pyo3-object_store/src/azure/store.rs
@@ -92,7 +92,6 @@ impl PyAzureStore {
         kwargs: Option<PyAzureConfig>,
     ) -> PyObjectStoreResult<Self> {
         let mut builder = MicrosoftAzureBuilder::from_env();
-        builder = PyAzureConfig::OVERRIDDEN_DEFAULTS().apply_config(builder);
         let mut config = config.unwrap_or_default();
         if let Some(container) = container.clone() {
             // Note: we apply the bucket to the config, not directly to the builder, so they stay
@@ -259,14 +258,6 @@ impl<'py> FromPyObject<'py> for PyAzureConfig {
 impl PyAzureConfig {
     fn new() -> Self {
         Self(HashMap::new())
-    }
-
-    /// Default values that we opt into that differ from the upstream object_store defaults
-    #[allow(non_snake_case)]
-    fn OVERRIDDEN_DEFAULTS() -> Self {
-        let mut map = HashMap::with_capacity(1);
-        map.insert(AzureConfigKey::UseAzureCli.into(), true.into());
-        Self(map)
     }
 
     fn apply_config(self, mut builder: MicrosoftAzureBuilder) -> MicrosoftAzureBuilder {


### PR DESCRIPTION
Closes https://github.com/developmentseed/obstore/issues/324, reverts https://github.com/developmentseed/obstore/pull/292.

I didn't realize that #292 would _prevent_ falling back to instance metadata authentication. 

In my first read of https://github.com/apache/arrow-rs/blob/95c42a7e235dbc689dbf50636aea514331c714c9/object_store/src/azure/builder.rs#L1015-L1028 I thought that it would _attempt_ CLI authentication, and if it can't do that, it'll fall back to instance metadata authentication.

But this is not true. If `use_azure_cli` is turned on, then **every** user who wants to use instance authentication needs to explicitly turn CLI authentication **off**.

cc @daviewales