### PR TITLE
Only build mkdocs social plugin on ci

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,10 @@ jobs:
   build:
     name: Deploy Python docs
     runs-on: ubuntu-latest
+    # Used for configuring social plugin in mkdocs.yml
+    # Unclear if this is always set in github actions
+    env:
+      CI: "TRUE"
     steps:
       - uses: actions/checkout@v4
         # We need to additionally fetch the gh-pages branch for mike deploy

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -126,7 +126,8 @@ extra_css:
 plugins:
   - blog
   - search
-  - social
+  - social:
+      enabled: !ENV [CI, false]
   - mike:
       alias_type: "copy"
       canonical_version: "latest"


### PR DESCRIPTION
Solves some problems with not being able to get cairo installed locally