### PR TITLE
Fsspec fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,18 @@
 
 ### Breaking changes :wrench:
 
+#### Object store methods
+
+No breaking changes.
+
+#### Store constructors
+
 - Removed `S3Store.from_session` and `S3Store._from_native`. Use credential providers instead.
-- Rename `AsyncFsspecStore` to `FsspecStore` by @kylebarron in https://github.com/developmentseed/obstore/pull/297
 - Reduce the config variations supported for input. I.e. we previously allowed `region`, `aws_region`, `REGION` or `AWS_REGION` as a config parameter to `S3Store`, which could make it confusing. We now only support a single config input value for each underlying concept. https://github.com/developmentseed/obstore/pull/323
+
+#### Fsspec
+
+- Rename `AsyncFsspecStore` to `FsspecStore` by @kylebarron in https://github.com/developmentseed/obstore/pull/297
 
 ### Bug fixes :bug:
 

--- a/tests/test_fsspec.py
+++ b/tests/test_fsspec.py
@@ -176,21 +176,24 @@ def test_split_path(fs: FsspecStore):
     assert fs._split_path("mybucket/path/to/file") == ("mybucket", "path/to/file")
     assert fs._split_path("data-bucket/") == ("data-bucket", "")
 
-    # url format, wrong porotocol
+    # url format, wrong protocol
     with pytest.raises(ValueError, match="Expected protocol to be s3. Got gs"):
         fs._split_path("gs://data-bucket/")
 
     # in url format, without bucket
-    fs._protocol = "file"
-    assert fs._split_path("file:///mybucket/path/to/file") == (
+    file_fs = FsspecStore("file")
+    assert file_fs._split_path("file:///mybucket/path/to/file") == (
         "",
         "/mybucket/path/to/file",
     )
-    assert fs._split_path("file:///data-bucket/") == ("", "/data-bucket/")
+    assert file_fs._split_path("file:///data-bucket/") == ("", "/data-bucket/")
 
     # path format, without bucket
-    assert fs._split_path("/mybucket/path/to/file") == ("", "/mybucket/path/to/file")
-    assert fs._split_path("/data-bucket/") == ("", "/data-bucket/")
+    assert file_fs._split_path("/mybucket/path/to/file") == (
+        "",
+        "/mybucket/path/to/file",
+    )
+    assert file_fs._split_path("/data-bucket/") == ("", "/data-bucket/")
 
 
 def test_list(fs: FsspecStore):

--- a/tests/test_fsspec.py
+++ b/tests/test_fsspec.py
@@ -177,7 +177,7 @@ def test_split_path(fs: FsspecStore):
     assert fs._split_path("data-bucket/") == ("data-bucket", "")
 
     # url format, wrong porotocol
-    with pytest.raises(ValueError, match="Expect protocol to be s3. Got gs"):
+    with pytest.raises(ValueError, match="Expected protocol to be s3. Got gs"):
         fs._split_path("gs://data-bucket/")
 
     # in url format, without bucket


### PR DESCRIPTION
- We override the value of `self.protocol` so that it's not `"abstract"`. Needed for `duckdb.register_filesystem` to work (ref #328 )
- We override the default value of `detail=False` instead of `detail=True` in `_ls`. It seems like every implementation does this 🤷‍♂️ https://github.com/fsspec/s3fs/issues/945, https://github.com/fsspec/gcsfs/blob/d0fd744e7ba30edae432928e007993114719961f/gcsfs/core.py#L1049, even though the base class is `detail=True`


cc @machichima 