### PR TITLE
Fix credential extraction; never try to await non-awaitable object

### DIFF
--- a/pyo3-object_store/src/credentials.rs
+++ b/pyo3-object_store/src/credentials.rs
@@ -1,5 +1,8 @@
 use chrono::Utc;
 use chrono::{DateTime, TimeDelta};
+use pyo3::intern;
+use pyo3::prelude::*;
+use pyo3::types::PyTuple;
 use std::future::Future;
 use tokio::sync::Mutex;
 
@@ -86,4 +89,13 @@ impl<T: Clone + Send> TokenCache<T> {
 
         Ok(token)
     }
+}
+
+/// Check whether a Python object is awaitable
+pub(crate) fn is_awaitable<'py>(ob: &Bound<'py, PyAny>) -> PyResult<bool> {
+    let py = ob.py();
+    let inspect_mod = py.import(intern!(py, "inspect"))?;
+    inspect_mod
+        .call_method1(intern!(py, "isawaitable"), PyTuple::new(py, [ob])?)?
+        .extract::<bool>()
 }

--- a/pyo3-object_store/src/credentials.rs
+++ b/pyo3-object_store/src/credentials.rs
@@ -92,7 +92,7 @@ impl<T: Clone + Send> TokenCache<T> {
 }
 
 /// Check whether a Python object is awaitable
-pub(crate) fn is_awaitable<'py>(ob: &Bound<'py, PyAny>) -> PyResult<bool> {
+pub(crate) fn is_awaitable(ob: &Bound<PyAny>) -> PyResult<bool> {
     let py = ob.py();
     let inspect_mod = py.import(intern!(py, "inspect"))?;
     inspect_mod


### PR DESCRIPTION
If the result of the credential provider is awaitable (i.e. we check `inspect.isawaitable` now), then it's an async credential provider. Otherwise, we try to extract the value, and fail if it doesn't work. 

This ensures that if the synchronous credential extraction fails, then we don't try to await a non-awaitable object.

Closes #344 