### PR TITLE
Implement `__eq__` natively on store classes

### DIFF
--- a/obstore/python/obstore/_store/__init__.pyi
+++ b/obstore/python/obstore/_store/__init__.pyi
@@ -172,6 +172,7 @@ class LocalStore:
         ```
         """
 
+    def __eq__(self, value: object) -> bool: ...
     def __getnewargs_ex__(self): ...
     @property
     def prefix(self) -> Path | None:

--- a/obstore/python/obstore/_store/_aws.pyi
+++ b/obstore/python/obstore/_store/_aws.pyi
@@ -537,6 +537,7 @@ class S3Store:
 
         """
 
+    def __eq__(self, value: object) -> bool: ...
     def __getnewargs_ex__(self): ...
     @property
     def prefix(self) -> str | None:

--- a/obstore/python/obstore/_store/_azure.pyi
+++ b/obstore/python/obstore/_store/_azure.pyi
@@ -388,6 +388,7 @@ class AzureStore:
 
         """
 
+    def __eq__(self, value: object) -> bool: ...
     def __getnewargs_ex__(self): ...
     @property
     def prefix(self) -> str | None:

--- a/obstore/python/obstore/_store/_gcs.pyi
+++ b/obstore/python/obstore/_store/_gcs.pyi
@@ -187,6 +187,7 @@ class GCSStore:
 
         """
 
+    def __eq__(self, value: object) -> bool: ...
     def __getnewargs_ex__(self): ...
     @property
     def prefix(self) -> str | None:

--- a/obstore/python/obstore/_store/_http.pyi
+++ b/obstore/python/obstore/_store/_http.pyi
@@ -40,6 +40,7 @@ class HTTPStore:
         This is an alias of [`HTTPStore.__init__`][obstore.store.HTTPStore.__init__].
         """
 
+    def __eq__(self, value: object) -> bool: ...
     def __getnewargs_ex__(self): ...
     @property
     def url(self) -> str:

--- a/pyo3-object_store/src/azure/store.rs
+++ b/pyo3-object_store/src/azure/store.rs
@@ -17,6 +17,7 @@ use crate::path::PyPath;
 use crate::retry::PyRetryConfig;
 use crate::{MaybePrefixedStore, PyUrl};
 
+#[derive(Debug, Clone, PartialEq)]
 struct AzureConfig {
     prefix: Option<PyPath>,
     config: PyAzureConfig,
@@ -152,6 +153,15 @@ impl PyAzureStore {
         kwargs.set_item("retry_config", retry_config)?;
         kwargs.set_item("credential_provider", credential_provider)?;
         Ok(cls.call((), Some(&kwargs))?.unbind())
+    }
+
+    fn __eq__(&self, other: &Bound<PyAny>) -> bool {
+        // Ensure we never error on __eq__ by returning false if the other object is not the same
+        // type
+        other
+            .downcast::<PyAzureStore>()
+            .map(|other| self.config == other.get().config)
+            .unwrap_or(false)
     }
 
     fn __getnewargs_ex__(&self, py: Python) -> PyResult<PyObject> {

--- a/pyo3-object_store/src/client.rs
+++ b/pyo3-object_store/src/client.rs
@@ -41,7 +41,7 @@ impl<'py> IntoPyObject<'py> for &PyClientConfigKey {
 }
 
 /// A wrapper around `ClientOptions` that implements [`FromPyObject`].
-#[derive(Clone, Debug, FromPyObject, IntoPyObject, IntoPyObjectRef)]
+#[derive(Clone, Debug, FromPyObject, IntoPyObject, IntoPyObjectRef, PartialEq)]
 pub struct PyClientOptions(HashMap<PyClientConfigKey, PyConfigValue>);
 
 impl From<PyClientOptions> for ClientOptions {

--- a/pyo3-object_store/src/gcp/store.rs
+++ b/pyo3-object_store/src/gcp/store.rs
@@ -17,6 +17,7 @@ use crate::path::PyPath;
 use crate::retry::PyRetryConfig;
 use crate::{MaybePrefixedStore, PyUrl};
 
+#[derive(Debug, Clone, PartialEq)]
 struct GCSConfig {
     prefix: Option<PyPath>,
     config: PyGoogleConfig,
@@ -152,6 +153,15 @@ impl PyGCSStore {
         kwargs.set_item("retry_config", retry_config)?;
         kwargs.set_item("credential_provider", credential_provider)?;
         Ok(cls.call((), Some(&kwargs))?.unbind())
+    }
+
+    fn __eq__(&self, other: &Bound<PyAny>) -> bool {
+        // Ensure we never error on __eq__ by returning false if the other object is not the same
+        // type
+        other
+            .downcast::<PyGCSStore>()
+            .map(|other| self.config == other.get().config)
+            .unwrap_or(false)
     }
 
     fn __getnewargs_ex__(&self, py: Python) -> PyResult<PyObject> {

--- a/pyo3-object_store/src/http.rs
+++ b/pyo3-object_store/src/http.rs
@@ -9,6 +9,7 @@ use crate::error::PyObjectStoreResult;
 use crate::retry::PyRetryConfig;
 use crate::{PyClientOptions, PyUrl};
 
+#[derive(Debug, Clone, PartialEq)]
 struct HTTPConfig {
     url: PyUrl,
     client_options: Option<PyClientOptions>,
@@ -96,6 +97,15 @@ impl PyHttpStore {
         kwargs.set_item("client_options", client_options)?;
         kwargs.set_item("retry_config", retry_config)?;
         Ok(cls.call((), Some(&kwargs))?.unbind())
+    }
+
+    fn __eq__(&self, other: &Bound<PyAny>) -> bool {
+        // Ensure we never error on __eq__ by returning false if the other object is not the same
+        // type
+        other
+            .downcast::<PyHttpStore>()
+            .map(|other| self.config == other.get().config)
+            .unwrap_or(false)
     }
 
     fn __getnewargs_ex__(&self, py: Python) -> PyResult<PyObject> {

--- a/pyo3-object_store/src/local.rs
+++ b/pyo3-object_store/src/local.rs
@@ -11,7 +11,7 @@ use pyo3::{intern, IntoPyObjectExt};
 use crate::error::PyObjectStoreResult;
 use crate::PyUrl;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 struct LocalConfig {
     prefix: Option<std::path::PathBuf>,
     automatic_cleanup: bool,
@@ -104,6 +104,15 @@ impl PyLocalStore {
         kwargs.set_item("automatic_cleanup", automatic_cleanup)?;
         kwargs.set_item("mkdir", mkdir)?;
         Ok(cls.call((), Some(&kwargs))?.unbind())
+    }
+
+    fn __eq__(&self, other: &Bound<PyAny>) -> bool {
+        // Ensure we never error on __eq__ by returning false if the other object is not the same
+        // type
+        other
+            .downcast::<PyLocalStore>()
+            .map(|other| self.config == other.get().config)
+            .unwrap_or(false)
     }
 
     fn __getnewargs_ex__(&self, py: Python) -> PyResult<PyObject> {

--- a/pyo3-object_store/src/memory.rs
+++ b/pyo3-object_store/src/memory.rs
@@ -6,6 +6,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyString;
 
 /// A Python-facing wrapper around an [`InMemory`].
+#[derive(Debug, Clone)]
 #[pyclass(name = "MemoryStore", frozen, subclass)]
 pub struct PyMemoryStore(Arc<InMemory>);
 
@@ -37,5 +38,10 @@ impl PyMemoryStore {
     #[new]
     fn py_new() -> Self {
         Self(Arc::new(InMemory::new()))
+    }
+
+    fn __eq__(slf: Py<Self>, other: &Bound<PyAny>) -> bool {
+        // Two memory stores are equal only if they are the same object
+        slf.is(other)
     }
 }

--- a/pyo3-object_store/src/path.rs
+++ b/pyo3-object_store/src/path.rs
@@ -2,7 +2,7 @@ use object_store::path::Path;
 use pyo3::prelude::*;
 use pyo3::types::PyString;
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) struct PyPath(Path);
 
 impl<'py> FromPyObject<'py> for PyPath {

--- a/pyo3-object_store/src/retry.rs
+++ b/pyo3-object_store/src/retry.rs
@@ -4,7 +4,7 @@ use object_store::{BackoffConfig, RetryConfig};
 use pyo3::intern;
 use pyo3::prelude::*;
 
-#[derive(Clone, Debug, IntoPyObject, IntoPyObjectRef)]
+#[derive(Clone, Debug, IntoPyObject, IntoPyObjectRef, PartialEq)]
 pub struct PyBackoffConfig {
     #[pyo3(item)]
     init_backoff: Duration,
@@ -51,7 +51,7 @@ impl From<BackoffConfig> for PyBackoffConfig {
     }
 }
 
-#[derive(Clone, Debug, IntoPyObject, IntoPyObjectRef)]
+#[derive(Clone, Debug, IntoPyObject, IntoPyObjectRef, PartialEq)]
 pub struct PyRetryConfig {
     #[pyo3(item)]
     backoff: PyBackoffConfig,

--- a/pyo3-object_store/src/url.rs
+++ b/pyo3-object_store/src/url.rs
@@ -6,7 +6,7 @@ use pyo3::FromPyObject;
 use url::Url;
 
 /// A wrapper around [`url::Url`] that implements [`FromPyObject`].
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct PyUrl(Url);
 
 impl PyUrl {

--- a/tests/store/test_azure.py
+++ b/tests/store/test_azure.py
@@ -15,9 +15,20 @@ def test_overlapping_config_keys():
 
 
 def test_eq():
-    store = AzureStore("bucket", client_options={"timeout": "10s"})
-    store2 = AzureStore("bucket", client_options={"timeout": "10s"})
-    store3 = AzureStore("bucket")
+    store = AzureStore(
+        "container",
+        account_name="account_name",
+        client_options={"timeout": "10s"},
+    )
+    store2 = AzureStore(
+        "container",
+        account_name="account_name",
+        client_options={"timeout": "10s"},
+    )
+    store3 = AzureStore(
+        "container",
+        account_name="account_name",
+    )
     assert store == store  # noqa: PLR0124
     assert store == store2
     assert store != store3

--- a/tests/store/test_azure.py
+++ b/tests/store/test_azure.py
@@ -12,3 +12,12 @@ def test_overlapping_config_keys():
         AzureStore(
             config={"azure_container_name": "test", "AZURE_CONTAINER_NAME": "test"},
         )
+
+
+def test_eq():
+    store = AzureStore("bucket", client_options={"timeout": "10s"})
+    store2 = AzureStore("bucket", client_options={"timeout": "10s"})
+    store3 = AzureStore("bucket")
+    assert store == store  # noqa: PLR0124
+    assert store == store2
+    assert store != store3

--- a/tests/store/test_gcs.py
+++ b/tests/store/test_gcs.py
@@ -10,3 +10,12 @@ def test_overlapping_config_keys():
 
     with pytest.raises(BaseError, match="Duplicate key"):
         GCSStore(config={"google_bucket": "test", "GOOGLE_BUCKET": "test"})
+
+
+def test_eq():
+    store = GCSStore("bucket", client_options={"timeout": "10s"})
+    store2 = GCSStore("bucket", client_options={"timeout": "10s"})
+    store3 = GCSStore("bucket")
+    assert store == store  # noqa: PLR0124
+    assert store == store2
+    assert store != store3

--- a/tests/store/test_http.py
+++ b/tests/store/test_http.py
@@ -7,3 +7,15 @@ def test_pickle():
     store = HTTPStore.from_url("https://example.com")
     new_store: HTTPStore = pickle.loads(pickle.dumps(store))
     assert store.url == new_store.url
+
+
+def test_eq():
+    store = HTTPStore.from_url("https://example.com", client_options={"timeout": "10s"})
+    store2 = HTTPStore.from_url(
+        "https://example.com",
+        client_options={"timeout": "10s"},
+    )
+    store3 = HTTPStore.from_url("https://example2.com")
+    assert store == store  # noqa: PLR0124
+    assert store == store2
+    assert store != store3

--- a/tests/store/test_local.py
+++ b/tests/store/test_local.py
@@ -69,3 +69,12 @@ def test_pickle(tmp_path: Path):
     obs.put(store, "path.txt", b"foo")
     new_store: LocalStore = pickle.loads(pickle.dumps(store))
     assert obs.get(new_store, "path.txt").bytes() == b"foo"
+
+
+def test_eq():
+    store = LocalStore(HERE, automatic_cleanup=True)
+    store2 = LocalStore(HERE, automatic_cleanup=True)
+    store3 = LocalStore(HERE)
+    assert store == store  # noqa: PLR0124
+    assert store == store2
+    assert store != store3

--- a/tests/store/test_memory.py
+++ b/tests/store/test_memory.py
@@ -1,0 +1,8 @@
+from obstore.store import MemoryStore
+
+
+def test_eq():
+    store = MemoryStore()
+    store2 = MemoryStore()
+    assert store == store  # noqa: PLR0124
+    assert store != store2

--- a/tests/store/test_s3.py
+++ b/tests/store/test_s3.py
@@ -122,3 +122,12 @@ async def test_invalid_credential_provider_async():
     store = S3Store("bucket", credential_provider=credential_provider)  # type: ignore
     with pytest.raises(UnauthenticatedError):
         await obs.list(store).collect_async()
+
+
+def test_eq():
+    store = S3Store("bucket", client_options={"timeout": "10s"})
+    store2 = S3Store("bucket", client_options={"timeout": "10s"})
+    store3 = S3Store("bucket")
+    assert store == store  # noqa: PLR0124
+    assert store == store2
+    assert store != store3


### PR DESCRIPTION
Closes https://github.com/developmentseed/obstore/issues/341.

cc @maxrjones we should be able to remove custom equality checking in https://github.com/zarr-developers/zarr-python/pull/1661