### PR TITLE
Bump to pyo3 0.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,9 +1359,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94caae805f998a07d33af06e6a3891e38556051b8045c615470a71590e13e78"
+checksum = "a7cfbf3f0feededcaa4d289fe3079b03659e85c5b5a177f4ba6fb01ab4fb3e39"
 dependencies = [
  "half",
  "libc",
@@ -1370,6 +1370,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "pyo3",
+ "pyo3-build-config",
  "rustc-hash",
 ]
 
@@ -1586,9 +1587,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.5"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+checksum = "7f1c6c3591120564d64db2261bec5f910ae454f01def849b9c22835a84695e86"
 dependencies = [
  "cfg-if",
  "chrono",
@@ -1607,9 +1608,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-arrow"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e51f9bb00155f44cd5b1b87199d364613b0cbdf082982f5f0d754287d9b4686"
+checksum = "9b7e4feb7c63063b5430a07c2c4406c12a24025f9b52791a77c6828cd4c2eb01"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -1625,9 +1626,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-async-runtimes"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977dc837525cfd22919ba6a831413854beb7c99a256c03bf8624ad707e45810e"
+checksum = "dd0b83dc42f9d41f50d38180dad65f0c99763b65a3ff2a81bf351dd35a1df8bf"
 dependencies = [
  "futures",
  "once_cell",
@@ -1638,9 +1639,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.5"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+checksum = "e9b6c2b34cf71427ea37c7001aefbaeb85886a074795e35f161f5aecc7620a7a"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1648,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "pyo3-bytes"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "bytes",
  "pyo3",
@@ -1656,9 +1657,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.5"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+checksum = "5507651906a46432cdda02cd02dd0319f6064f1374c9147c45b978621d2c3a9c"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1666,9 +1667,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-file"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3134dfe0d6458ea56d6c1cd4047c8894f331297aaf53eb9bf046ac7485dd469b"
+checksum = "b7fc1b57b1e7e2047d0907ded8086866ba8390a8b0ba512bcc35ececbffed72a"
 dependencies = [
  "pyo3",
  "skeptic",
@@ -1676,9 +1677,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.5"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+checksum = "b0d394b5b4fd8d97d48336bb0dd2aebabad39f1d294edd6bcd2cccf2eefe6f42"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1688,9 +1689,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.5"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+checksum = "fd72da09cfa943b1080f621f024d2ef7e2773df7badd51aa30a2be1f8caa7c8e"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1701,7 +1702,7 @@ dependencies = [
 
 [[package]]
 name = "pyo3-object_store"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2228,9 +2229,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,9 @@ futures = "0.3.31"
 http = "1.2"
 indexmap = "2"
 object_store = "0.12"
-pyo3 = { version = "0.23.4", features = ["macros", "indexmap"] }
-pyo3-async-runtimes = { version = "0.23", features = ["tokio-runtime"] }
-pyo3-file = "0.10"
+pyo3 = { version = "0.24", features = ["macros", "indexmap"] }
+pyo3-async-runtimes = { version = "0.24", features = ["tokio-runtime"] }
+pyo3-file = "0.11"
 thiserror = "1"
 tokio = "1.40"
 url = "2"

--- a/obstore/Cargo.toml
+++ b/obstore/Cargo.toml
@@ -26,7 +26,7 @@ http = { workspace = true }
 indexmap = { workspace = true }
 object_store = { workspace = true }
 pyo3 = { workspace = true, features = ["chrono"] }
-pyo3-arrow = "0.7.2"
+pyo3-arrow = "0.8"
 pyo3-async-runtimes = { workspace = true, features = ["tokio-runtime"] }
 pyo3-bytes = { path = "../pyo3-bytes" }
 pyo3-file = { workspace = true }

--- a/pyo3-bytes/Cargo.toml
+++ b/pyo3-bytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-bytes"
-version = "0.1.3"
+version = "0.2.0"
 authors = [
     "Kyle Barron <kyle@developmentseed.org>",
     "jesse rubin <jesse@dgi.com>",
@@ -17,7 +17,7 @@ rust-version = "1.75"
 [dependencies]
 # https://github.com/tokio-rs/bytes/releases/tag/v1.10.1
 bytes = "1.10.1"
-pyo3 = "0.23.4"
+pyo3 = "0.24"
 
 [lib]
 crate-type = ["rlib"]

--- a/pyo3-bytes/README.md
+++ b/pyo3-bytes/README.md
@@ -58,3 +58,10 @@ methods (with the same signature) as the Python `bytes` object.
 The Python type hints are available in the Github repo in the file `bytes.pyi`.
 I don't know the best way to distribute this to downstream projects. If you have
 an idea, create an issue to discuss.
+
+## Version compatibility
+
+| pyo3-bytes | pyo3 |
+| ---------- | ---- |
+| 0.1.x      | 0.23 |
+| 0.2.x      | 0.24 |

--- a/pyo3-object_store/Cargo.toml
+++ b/pyo3-object_store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-object_store"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Kyle Barron <kyle@developmentseed.org>"]
 edition = "2021"
 description = "object_store integration for pyo3."
@@ -25,8 +25,8 @@ itertools = "0.14.0"
 object_store = { version = "0.12", features = ["aws", "azure", "gcp", "http"] }
 # This is already an object_store dependency
 percent-encoding = "2.1"
-pyo3 = { version = "0.23.4", features = ["chrono", "indexmap"] }
-pyo3-async-runtimes = { version = "0.23", features = ["tokio-runtime"] }
+pyo3 = { version = "0.24", features = ["chrono", "indexmap"] }
+pyo3-async-runtimes = { version = "0.24", features = ["tokio-runtime"] }
 serde = "1"
 thiserror = "1"
 tokio = { version = "1.40", features = ["rt-multi-thread"] }

--- a/pyo3-object_store/README.md
+++ b/pyo3-object_store/README.md
@@ -61,3 +61,4 @@ We don't yet have a _great_ solution here for reusing the store builder type hin
 | pyo3-object_store | pyo3 | object_store |
 | ----------------- | ---- | ------------ |
 | 0.1.x             | 0.23 | 0.12         |
+| 0.2.x             | 0.24 | 0.12         |


### PR DESCRIPTION
### Change list

- bump to pyo3 0.24
- bump version in pyo3-bytes and pyo3-object_store