### PR TITLE
Revert obspec dependency

### DIFF
--- a/docs/api/attributes.md
+++ b/docs/api/attributes.md
@@ -1,0 +1,4 @@
+# Attributes
+
+::: obstore.Attribute
+::: obstore.Attributes

--- a/docs/api/get.md
+++ b/docs/api/get.md
@@ -6,6 +6,9 @@
 ::: obstore.get_range_async
 ::: obstore.get_ranges
 ::: obstore.get_ranges_async
+::: obstore.GetOptions
 ::: obstore.GetResult
 ::: obstore.BytesStream
 ::: obstore.Bytes
+::: obstore.OffsetRange
+::: obstore.SuffixRange

--- a/docs/api/list.md
+++ b/docs/api/list.md
@@ -3,3 +3,7 @@
 ::: obstore.list
 ::: obstore.list_with_delimiter
 ::: obstore.list_with_delimiter_async
+::: obstore.ObjectMeta
+::: obstore.ListResult
+::: obstore.ListStream
+::: obstore.ListChunkType

--- a/docs/api/put.md
+++ b/docs/api/put.md
@@ -2,3 +2,6 @@
 
 ::: obstore.put
 ::: obstore.put_async
+::: obstore.PutResult
+::: obstore.UpdateVersion
+::: obstore.PutMode

--- a/docs/blog/posts/obstore-0.4.md
+++ b/docs/blog/posts/obstore-0.4.md
@@ -72,7 +72,7 @@ Obstore version 0.5 is expected to improve on extensible credentials by enabling
 
 ## Return Arrow data from `list_with_delimiter`
 
-By default, the [`obstore.list`][] and [`obstore.list_with_delimiter`][] APIs [return standard Python `dict`s][obspec.ObjectMeta]. However, if you're listing a large bucket, the overhead of materializing all those Python objects can become significant.
+By default, the [`obstore.list`][] and [`obstore.list_with_delimiter`][] APIs [return standard Python `dict`s][obstore.ObjectMeta]. However, if you're listing a large bucket, the overhead of materializing all those Python objects can become significant.
 
 [`obstore.list`][] and [`obstore.list_with_delimiter`][] now both support a `return_arrow` keyword parameter. If set to `True`, an Arrow [`RecordBatch`][arro3.core.RecordBatch] or [`Table`][arro3.core.Table] will be returned, which is both faster and more memory efficient.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
       - api/put.md
       - api/rename.md
       - api/sign.md
+      - api/attributes.md
       - api/exceptions.md
       - api/file.md
       - obstore.fsspec: api/fsspec.md
@@ -157,7 +158,6 @@ plugins:
             - https://arrow.apache.org/docs/objects.inv
             - https://boto3.amazonaws.com/v1/documentation/api/latest/objects.inv
             - https://botocore.amazonaws.com/v1/documentation/api/latest/objects.inv
-            - https://developmentseed.org/obspec/latest/objects.inv
             - https://docs.aiohttp.org/en/stable/objects.inv
             - https://docs.pola.rs/api/python/stable/objects.inv
             - https://docs.python.org/3/objects.inv

--- a/obstore/python/obstore/__init__.py
+++ b/obstore/python/obstore/__init__.py
@@ -1,35 +1,8 @@
 from typing import TYPE_CHECKING
 
 from . import store
-from ._obstore import (
-    Bytes,
-    ___version,
-    copy,
-    copy_async,
-    delete,
-    delete_async,
-    get,
-    get_async,
-    get_range,
-    get_range_async,
-    get_ranges,
-    get_ranges_async,
-    head,
-    head_async,
-    list,  # noqa: A004
-    list_with_delimiter,
-    list_with_delimiter_async,
-    open_reader,
-    open_reader_async,
-    open_writer,
-    open_writer_async,
-    put,
-    put_async,
-    rename,
-    rename_async,
-    sign,
-    sign_async,
-)
+from ._obstore import *
+from ._obstore import ___version
 
 if TYPE_CHECKING:
     from . import _store, exceptions

--- a/obstore/python/obstore/_attributes.pyi
+++ b/obstore/python/obstore/_attributes.pyi
@@ -1,0 +1,47 @@
+from typing import Literal, TypeAlias
+
+Attribute: TypeAlias = (
+    Literal[
+        "Content-Disposition",
+        "Content-Encoding",
+        "Content-Language",
+        "Content-Type",
+        "Cache-Control",
+    ]
+    | str
+)
+"""Additional object attribute types.
+
+- `"Content-Disposition"`: Specifies how the object should be handled by a browser.
+
+    See [Content-Disposition](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition).
+
+- `"Content-Encoding"`: Specifies the encodings applied to the object.
+
+    See [Content-Encoding](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding).
+
+- `"Content-Language"`: Specifies the language of the object.
+
+    See [Content-Language](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Language).
+
+- `"Content-Type"`: Specifies the MIME type of the object.
+
+    This takes precedence over any client configuration.
+
+    See [Content-Type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type).
+
+- `"Cache-Control"`: Overrides cache control policy of the object.
+
+    See [Cache-Control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control).
+
+Any other string key specifies a user-defined metadata field for the object.
+"""
+
+Attributes: TypeAlias = dict[Attribute, str]
+"""Additional attributes of an object
+
+Attributes can be specified in [`put`][obstore.put]/[`put_async`][obstore.put_async] and
+retrieved from [`get`][obstore.get]/[`get_async`][obstore.get_async].
+
+Unlike ObjectMeta, Attributes are not returned by listing APIs
+"""

--- a/obstore/python/obstore/_buffered.pyi
+++ b/obstore/python/obstore/_buffered.pyi
@@ -2,9 +2,7 @@ import sys
 from contextlib import AbstractAsyncContextManager, AbstractContextManager
 from typing import Self
 
-# TODO: fix import
-from obspec._attributes import Attributes
-
+from ._attributes import Attributes
 from ._bytes import Bytes
 from ._list import ObjectMeta
 from ._store import ObjectStore

--- a/obstore/python/obstore/_get.pyi
+++ b/obstore/python/obstore/_get.pyi
@@ -1,12 +1,100 @@
 from collections.abc import Sequence
+from datetime import datetime
+from typing import TypedDict
 
-# TODO: fix imports
-from obspec._attributes import Attributes
-from obspec._get import GetOptions
-
+from ._attributes import Attributes
 from ._bytes import Bytes
 from ._list import ObjectMeta
-from ._store import ObjectStore
+from .store import ObjectStore
+
+class OffsetRange(TypedDict):
+    """Request all bytes starting from a given byte offset."""
+
+    offset: int
+    """The byte offset for the offset range request."""
+
+class SuffixRange(TypedDict):
+    """Request up to the last `n` bytes."""
+
+    suffix: int
+    """The number of bytes from the suffix to request."""
+
+class GetOptions(TypedDict, total=False):
+    """Options for a get request.
+
+    All options are optional.
+    """
+
+    if_match: str | None
+    """
+    Request will succeed if the `ObjectMeta::e_tag` matches
+    otherwise returning [`PreconditionError`][obstore.exceptions.PreconditionError].
+    See <https://datatracker.ietf.org/doc/html/rfc9110#name-if-match>
+    Examples:
+    ```text
+    If-Match: "xyzzy"
+    If-Match: "xyzzy", "r2d2xxxx", "c3piozzzz"
+    If-Match: *
+    ```
+    """
+
+    if_none_match: str | None
+    """
+    Request will succeed if the `ObjectMeta::e_tag` does not match
+    otherwise returning [`NotModifiedError`][obstore.exceptions.NotModifiedError].
+    See <https://datatracker.ietf.org/doc/html/rfc9110#section-13.1.2>
+    Examples:
+    ```text
+    If-None-Match: "xyzzy"
+    If-None-Match: "xyzzy", "r2d2xxxx", "c3piozzzz"
+    If-None-Match: *
+    ```
+    """
+
+    if_unmodified_since: datetime | None
+    """
+    Request will succeed if the object has been modified since
+    <https://datatracker.ietf.org/doc/html/rfc9110#section-13.1.3>
+    """
+
+    if_modified_since: datetime | None
+    """
+    Request will succeed if the object has not been modified since
+    otherwise returning [`PreconditionError`][obstore.exceptions.PreconditionError].
+    Some stores, such as S3, will only return `NotModified` for exact
+    timestamp matches, instead of for any timestamp greater than or equal.
+    <https://datatracker.ietf.org/doc/html/rfc9110#section-13.1.4>
+    """
+
+    range: tuple[int, int] | list[int] | OffsetRange | SuffixRange
+    """
+    Request transfer of only the specified range of bytes
+    otherwise returning [`NotModifiedError`][obstore.exceptions.NotModifiedError].
+    The semantics of this tuple are:
+    - `(int, int)`: Request a specific range of bytes `(start, end)`.
+        If the given range is zero-length or starts after the end of the object, an
+        error will be returned. Additionally, if the range ends after the end of the
+        object, the entire remainder of the object will be returned. Otherwise, the
+        exact requested range will be returned.
+        The `end` offset is _exclusive_.
+    - `{"offset": int}`: Request all bytes starting from a given byte offset.
+        This is equivalent to `bytes={int}-` as an HTTP header.
+    - `{"suffix": int}`: Request the last `int` bytes. Note that here, `int` is _the
+        size of the request_, not the byte offset. This is equivalent to `bytes=-{int}`
+        as an HTTP header.
+    <https://datatracker.ietf.org/doc/html/rfc9110#name-range>
+    """
+
+    version: str | None
+    """
+    Request a particular object version
+    """
+
+    head: bool
+    """
+    Request transfer of no content
+    <https://datatracker.ietf.org/doc/html/rfc9110#name-head>
+    """
 
 class GetResult:
     """Result for a get request.
@@ -36,9 +124,6 @@ class GetResult:
 
     Note that after calling `bytes`, `bytes_async`, or `stream`, you will no longer be
     able to call other methods on this object, such as the `meta` attribute.
-
-    This implements [`obspec.GetResult`][], but is redefined here to specialize the
-    exact instance of the `bytes` return type to be [`obstore.Bytes`][].
     """
 
     @property
@@ -126,9 +211,6 @@ class BytesStream:
 
         To fix this, set the `timeout` parameter in the
         [`client_options`][obstore.store.ClientConfig] passed when creating the store.
-
-    This implements [`obspec.BufferStream`][], but is redefined here to specialize the
-    exact instance of the buffer return type to be [`obstore.Bytes`][].
     """
 
     def __aiter__(self) -> BytesStream:

--- a/obstore/python/obstore/_head.pyi
+++ b/obstore/python/obstore/_head.pyi
@@ -1,6 +1,4 @@
-# TODO: fix improt
-from obspec._meta import ObjectMeta
-
+from ._list import ObjectMeta
 from .store import ObjectStore
 
 def head(store: ObjectStore, path: str) -> ObjectMeta:

--- a/obstore/python/obstore/_obstore.pyi
+++ b/obstore/python/obstore/_obstore.pyi
@@ -1,4 +1,6 @@
 from . import _store as _store
+from ._attributes import Attribute as Attribute
+from ._attributes import Attributes as Attributes
 from ._buffered import AsyncReadableFile as AsyncReadableFile
 from ._buffered import AsyncWritableFile as AsyncWritableFile
 from ._buffered import ReadableFile as ReadableFile
@@ -13,7 +15,10 @@ from ._copy import copy_async as copy_async
 from ._delete import delete as delete
 from ._delete import delete_async as delete_async
 from ._get import BytesStream as BytesStream
+from ._get import GetOptions as GetOptions
 from ._get import GetResult as GetResult
+from ._get import OffsetRange as OffsetRange
+from ._get import SuffixRange as SuffixRange
 from ._get import get as get
 from ._get import get_async as get_async
 from ._get import get_range as get_range
@@ -22,9 +27,16 @@ from ._get import get_ranges as get_ranges
 from ._get import get_ranges_async as get_ranges_async
 from ._head import head as head
 from ._head import head_async as head_async
+from ._list import ListChunkType as ListChunkType
+from ._list import ListResult as ListResult
+from ._list import ListStream as ListStream
+from ._list import ObjectMeta as ObjectMeta
 from ._list import list as list  # noqa: A004
 from ._list import list_with_delimiter as list_with_delimiter
 from ._list import list_with_delimiter_async as list_with_delimiter_async
+from ._put import PutMode as PutMode
+from ._put import PutResult as PutResult
+from ._put import UpdateVersion as UpdateVersion
 from ._put import put as put
 from ._put import put_async as put_async
 from ._rename import rename as rename

--- a/obstore/python/obstore/_put.pyi
+++ b/obstore/python/obstore/_put.pyi
@@ -1,18 +1,60 @@
 import sys
 from collections.abc import AsyncIterable, AsyncIterator, Iterable, Iterator
 from pathlib import Path
-from typing import IO
+from typing import IO, Literal, TypeAlias, TypedDict
 
-# TODO: Fix imports
-from obspec._attributes import Attributes
-from obspec._put import PutMode, PutResult
-
+from ._attributes import Attributes
 from .store import ObjectStore
 
 if sys.version_info >= (3, 12):
     from collections.abc import Buffer
 else:
     from typing_extensions import Buffer
+
+class UpdateVersion(TypedDict, total=False):
+    """Uniquely identifies a version of an object to update.
+
+    Stores will use differing combinations of `e_tag` and `version` to provide
+    conditional updates, and it is therefore recommended applications preserve both
+    """
+
+    e_tag: str | None
+    """The unique identifier for the newly created object.
+    <https://datatracker.ietf.org/doc/html/rfc9110#name-etag>
+    """
+
+    version: str | None
+    """A version indicator for the newly created object."""
+
+PutMode: TypeAlias = Literal["create", "overwrite"] | UpdateVersion
+"""Configure preconditions for the put operation
+There are three modes:
+- Overwrite: Perform an atomic write operation, overwriting any object present at the
+  provided path.
+- Create: Perform an atomic write operation, returning
+  [`AlreadyExistsError`][obstore.exceptions.AlreadyExistsError] if an object already
+  exists at the provided path.
+- Update: Perform an atomic write operation if the current version of the object matches
+  the provided [`UpdateVersion`][obstore.UpdateVersion], returning
+  [`PreconditionError`][obstore.exceptions.PreconditionError] otherwise.
+If a string is provided, it must be one of:
+- `"overwrite"`
+- `"create"`
+If a `dict` is provided, it must meet the criteria of
+[`UpdateVersion`][obstore.UpdateVersion].
+"""
+
+class PutResult(TypedDict):
+    """Result for a put request."""
+
+    e_tag: str | None
+    """
+    The unique identifier for the newly created object
+    <https://datatracker.ietf.org/doc/html/rfc9110#name-etag>
+    """
+
+    version: str | None
+    """A version indicator for the newly created object."""
 
 def put(
     store: ObjectStore,
@@ -65,7 +107,7 @@ def put(
               protocol.
 
     Keyword Args:
-        mode: Configure the [`PutMode`][obspec.PutMode] for this operation. Refer to the [`PutMode`][obspec.PutMode] docstring for more information.
+        mode: Configure the [`PutMode`][obstore.PutMode] for this operation. Refer to the [`PutMode`][obstore.PutMode] docstring for more information.
 
             If this provided and is not `"overwrite"`, a non-multipart upload will be performed. Defaults to `"overwrite"`.
         attributes: Provide a set of `Attributes`. Defaults to `None`.

--- a/obstore/python/obstore/fsspec.py
+++ b/obstore/python/obstore/fsspec.py
@@ -50,10 +50,7 @@ from obstore.store import from_url
 if TYPE_CHECKING:
     from collections.abc import Coroutine, Iterable
 
-    # TODO: fix import
-    from obspec._attributes import Attributes
-
-    from obstore import Bytes, ReadableFile, WritableFile
+    from obstore import Attributes, Bytes, ReadableFile, WritableFile
     from obstore.store import (
         AzureConfig,
         ClientConfig,

--- a/obstore/python/obstore/store.py
+++ b/obstore/python/obstore/store.py
@@ -25,12 +25,16 @@ if TYPE_CHECKING:
     from typing import IO, Literal
 
     from arro3.core import RecordBatch, Table
-    from obspec._attributes import Attributes
-    from obspec._get import GetOptions
-    from obspec._list import ListResult, ListStream
-    from obspec._meta import ObjectMeta
-    from obspec._put import PutMode, PutResult
 
+    from obstore import (
+        Attributes,
+        GetOptions,
+        ListResult,
+        ListStream,
+        ObjectMeta,
+        PutMode,
+        PutResult,
+    )
     from obstore._obstore import Bytes, GetResult
     from obstore._store import (
         AzureAccessKey,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ dev-dependencies = [
     "mkdocstrings-python>=1.13.0",
     "mkdocstrings>=0.27.0",
     "moto[s3,server]>=5.0.18",
-    "obspec>=0.1.0b1",
     "pandas>=2.2.3",
     "pip>=24.2",
     "pyarrow>=17.0.0",

--- a/tests/test_obspec.py
+++ b/tests/test_obspec.py
@@ -1,66 +1,68 @@
-from arro3.core import RecordBatch, Table
+# ruff: noqa: ERA001
 
-# TODO: fix imports
-from obspec._get import Get, GetAsync
-from obspec._list import List, ListWithDelimiter, ListWithDelimiterAsync
-from obspec._put import Put, PutAsync
+# from arro3.core import RecordBatch, Table
 
-from obstore.store import MemoryStore
+# # TODO: fix imports
+# from obspec._get import Get, GetAsync
+# from obspec._list import List, ListWithDelimiter, ListWithDelimiterAsync
+# from obspec._put import Put, PutAsync
 
-
-def store():
-    return MemoryStore()
+# from obstore.store import MemoryStore
 
 
-def accepts_get(store: Get):
-    store.get("path")
+# def store():
+#     return MemoryStore()
 
 
-async def accepts_get_async(store: GetAsync):
-    await store.get_async("path")
+# def accepts_get(store: Get):
+#     store.get("path")
 
 
-def accepts_list(store: List):
-    objects = store.list().collect()
-    assert isinstance(objects, list)
-
-    objects = next(store.list(return_arrow=True))
-    _rb = RecordBatch(objects)
+# async def accepts_get_async(store: GetAsync):
+#     await store.get_async("path")
 
 
-def accepts_list_with_delimiter(store: ListWithDelimiter):
-    objects = store.list_with_delimiter()
-    assert isinstance(objects["objects"], list)
+# def accepts_list(store: List):
+#     objects = store.list().collect()
+#     assert isinstance(objects, list)
 
-    objects = store.list_with_delimiter(return_arrow=True)
-    _rb = Table(objects["objects"])
-
-
-async def accepts_list_with_delimiter_async(store: ListWithDelimiterAsync):
-    objects = await store.list_with_delimiter_async()
-    assert isinstance(objects["objects"], list)
-
-    objects = await store.list_with_delimiter_async(return_arrow=True)
-    _rb = Table(objects["objects"])
+#     objects = next(store.list(return_arrow=True))
+#     _rb = RecordBatch(objects)
 
 
-def accepts_put(store: Put):
-    store.put("path", b"content")
+# def accepts_list_with_delimiter(store: ListWithDelimiter):
+#     objects = store.list_with_delimiter()
+#     assert isinstance(objects["objects"], list)
+
+#     objects = store.list_with_delimiter(return_arrow=True)
+#     _rb = Table(objects["objects"])
 
 
-async def accepts_put_async(store: PutAsync):
-    await store.put_async("path", b"content")
+# async def accepts_list_with_delimiter_async(store: ListWithDelimiterAsync):
+#     objects = await store.list_with_delimiter_async()
+#     assert isinstance(objects["objects"], list)
+
+#     objects = await store.list_with_delimiter_async(return_arrow=True)
+#     _rb = Table(objects["objects"])
 
 
-async def test_typing():
-    store = MemoryStore()
+# def accepts_put(store: Put):
+#     store.put("path", b"content")
 
-    # Make sure to put "put" first
-    accepts_put(store)
-    await accepts_put_async(store)
 
-    accepts_get(store)
-    await accepts_get_async(store)
-    accepts_list(store)
-    accepts_list_with_delimiter(store)
-    await accepts_list_with_delimiter_async(store)
+# async def accepts_put_async(store: PutAsync):
+#     await store.put_async("path", b"content")
+
+
+# async def test_typing():
+#     store = MemoryStore()
+
+#     # Make sure to put "put" first
+#     accepts_put(store)
+#     await accepts_put_async(store)
+
+#     accepts_get(store)
+#     await accepts_get_async(store)
+#     accepts_list(store)
+#     accepts_list_with_delimiter(store)
+#     await accepts_list_with_delimiter_async(store)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -1426,15 +1425,6 @@ wheels = [
 ]
 
 [[package]]
-name = "obspec"
-version = "0.1.0b1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/50/4a/ef272abf32b3d397727224987ed0fe4f55589c7e6ab608f2e62dc60d8be1/obspec-0.1.0b1.tar.gz", hash = "sha256:4d3bee05724efe27d6974b1766bcd65dcd32a2440a3bc27469f0c5f0425d82fc", size = 90417 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/58/7783b352fcdd95b50a8246e405281890bd9db14afc0d416cbc304bc42e04/obspec-0.1.0b1-py3-none-any.whl", hash = "sha256:6a1f4475dbe4a950996b49eba993bab6bef0f0d85847e49183a5f58a4f1dcc04", size = 14807 },
-]
-
-[[package]]
 name = "openapi-schema-validator"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2384,7 +2374,6 @@ dev = [
     { name = "mkdocstrings" },
     { name = "mkdocstrings-python" },
     { name = "moto", extra = ["s3", "server"] },
-    { name = "obspec" },
     { name = "pandas" },
     { name = "pip" },
     { name = "polars" },
@@ -2414,7 +2403,6 @@ dev = [
     { name = "mkdocstrings", specifier = ">=0.27.0" },
     { name = "mkdocstrings-python", specifier = ">=1.13.0" },
     { name = "moto", extras = ["s3", "server"], specifier = ">=5.0.18" },
-    { name = "obspec", specifier = ">=0.1.0b1" },
     { name = "pandas", specifier = ">=2.2.3" },
     { name = "pip", specifier = ">=24.2" },
     { name = "polars", specifier = ">=1.24.0" },


### PR DESCRIPTION
Closes https://github.com/developmentseed/obstore/issues/359, reverts https://github.com/developmentseed/obstore/pull/337

Due to complications trying to get exceptions working (#342 , https://github.com/developmentseed/obstore/pull/346), I'm putting off obspec until a future obstore release.