### PR TITLE
In `AzureStore` standardize on `container_name` argument name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.6.0] -
+
+### Breaking changes :wrench:
+
+#### Object store methods
+
+No breaking changes.
+
+#### Store constructors
+
+- In the `AzureStore` constructor, the `container` positional argument was renamed to `container_name` to match the `container_name` key in `AzureConfig`.
+
+  This is a breaking change if you had been calling `AzureStore(container="my container name")`. This is not breaking if you had been using it as a positional argument `AzureStore("my container name")` or if you had already been using `AzureStore(container_name="my container name")`.
+
+  The idea here is that we want one and only one argument name for each underlying config parameter. Most of these breaking changes took place in 0.5.0, but this was overlooked.
+
+
 ## [0.5.1] - 2025-03-17
 
 ### Bug fixes :bug:

--- a/obstore/python/obstore/_store/_azure.pyi
+++ b/obstore/python/obstore/_store/_azure.pyi
@@ -326,19 +326,19 @@ class AzureStore:
 
     def __init__(
         self,
-        container: str | None = None,
+        container_name: str | None = None,
         *,
         prefix: str | None = None,
         config: AzureConfig | None = None,
         client_options: ClientConfig | None = None,
         retry_config: RetryConfig | None = None,
         credential_provider: AzureCredentialProvider | None = None,
-        **kwargs: Unpack[AzureConfig],
+        **kwargs: Unpack[AzureConfig],  # type: ignore[GeneralTypeIssues] (container_name key overlaps with positional arg)
     ) -> None:
         """Construct a new AzureStore.
 
         Args:
-            container: the name of the container.
+            container_name: the name of the container.
 
         Keyword Args:
             prefix: A prefix within the bucket to use for all operations.

--- a/pyo3-object_store/CHANGELOG.md
+++ b/pyo3-object_store/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.3.0] -
+
+### Breaking changes :wrench:
+
+#### Store constructors
+
+- In the `AzureStore` constructor, the `container` positional argument was renamed to `container_name` to match the `container_name` key in `AzureConfig`.
+
+  This is a breaking change if you had been calling `AzureStore(container="my container name")`. This is not breaking if you had been using it as a positional argument `AzureStore("my container name")` or if you had already been using `AzureStore(container_name="my container name")`.
+
+## [0.2.0] - 2025-03-14
+
+- Bump to pyo3 0.24.
+
 ## [0.1.0] - 2025-03-14
 
 - Initial release.

--- a/pyo3-object_store/src/azure/store.rs
+++ b/pyo3-object_store/src/azure/store.rs
@@ -83,9 +83,9 @@ impl PyAzureStore {
 impl PyAzureStore {
     // Create from parameters
     #[new]
-    #[pyo3(signature = (container=None, *, prefix=None, config=None, client_options=None, retry_config=None, credential_provider=None, **kwargs))]
+    #[pyo3(signature = (container_name=None, *, prefix=None, config=None, client_options=None, retry_config=None, credential_provider=None, **kwargs))]
     fn new(
-        container: Option<String>,
+        container_name: Option<String>,
         prefix: Option<PyPath>,
         config: Option<PyAzureConfig>,
         client_options: Option<PyClientOptions>,
@@ -95,10 +95,10 @@ impl PyAzureStore {
     ) -> PyObjectStoreResult<Self> {
         let mut builder = MicrosoftAzureBuilder::from_env();
         let mut config = config.unwrap_or_default();
-        if let Some(container) = container.clone() {
+        if let Some(container_name) = container_name {
             // Note: we apply the bucket to the config, not directly to the builder, so they stay
             // in sync.
-            config.insert_raising_if_exists(AzureConfigKey::ContainerName, container)?;
+            config.insert_raising_if_exists(AzureConfigKey::ContainerName, container_name)?;
         }
         let combined_config = combine_config_kwargs(Some(config), kwargs)?;
         builder = combined_config.clone().apply_config(builder);


### PR DESCRIPTION
### Change list

- Previously we had both `container` as a positional argument **and** `container_name` as a keyword-only argument. This renames the positional argument to `container_name`, so we only have one name by which to pass it down.
- Update changelog