### PR TITLE
Fix `_buffered.pyi` for python 3.9

### DIFF
--- a/obstore/python/obstore/_buffered.pyi
+++ b/obstore/python/obstore/_buffered.pyi
@@ -1,11 +1,15 @@
 import sys
 from contextlib import AbstractAsyncContextManager, AbstractContextManager
-from typing import Self
 
 from ._attributes import Attributes
 from ._bytes import Bytes
 from ._list import ObjectMeta
 from ._store import ObjectStore
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 if sys.version_info >= (3, 12):
     from collections.abc import Buffer


### PR DESCRIPTION
Follow up from https://github.com/developmentseed/obstore/pull/372