### PR TITLE
Docs: Use source order in credential provider docs

### DIFF
--- a/docs/api/auth/azure.md
+++ b/docs/api/auth/azure.md
@@ -2,4 +2,8 @@
 
 ::: obstore.auth.azure.DEFAULT_SCOPES
 ::: obstore.auth.azure.AzureCredentialProvider
+    options:
+      members_order: source
 ::: obstore.auth.azure.AzureAsyncCredentialProvider
+    options:
+      members_order: source

--- a/docs/api/auth/boto3.md
+++ b/docs/api/auth/boto3.md
@@ -1,4 +1,8 @@
 # Boto3
 
 ::: obstore.auth.boto3.Boto3CredentialProvider
+    options:
+      members_order: source
 ::: obstore.auth.boto3.StsCredentialProvider
+    options:
+      members_order: source

--- a/docs/api/auth/earthdata.md
+++ b/docs/api/auth/earthdata.md
@@ -1,4 +1,8 @@
 # NASA Earthdata
 
 ::: obstore.auth.earthdata.NasaEarthdataCredentialProvider
+    options:
+      members_order: source
 ::: obstore.auth.earthdata.NasaEarthdataAsyncCredentialProvider
+    options:
+      members_order: source

--- a/docs/api/auth/google.md
+++ b/docs/api/auth/google.md
@@ -1,4 +1,8 @@
 # Google
 
 ::: obstore.auth.google.GoogleCredentialProvider
+    options:
+      members_order: source
 ::: obstore.auth.google.GoogleAsyncCredentialProvider
+    options:
+      members_order: source


### PR DESCRIPTION
So that `__init__` comes before `__call__`