### PR TITLE
Add typing extensions as runtime dependency

### DIFF
--- a/obstore/pyproject.toml
+++ b/obstore/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "obstore"
 requires-python = ">=3.9"
-dependencies = []
+dependencies = ["typing-extensions; python_version < '3.12'"]
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
@vincentsarago  I can still call obstore zero-dependency because this only applies to Python versions <3.12 😉 

Closes #375 