### PR TITLE
Publish pyo3-object_store compatibility releases for pyo3 0.23 and object_store 0.11

### DIFF
--- a/pyo3-object_store/CHANGELOG.md
+++ b/pyo3-object_store/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## [0.4.0] - 2025-03-24
+
+Compatibility release to use `pyo3-object_store` with `object_store` 0.11 and `pyo3` 0.24.
+
 ## [0.3.0] - 2025-03-24
 
-Compatibility release to use `pyo3-object_store` with `object_store` 0.11.
+Compatibility release to use `pyo3-object_store` with `object_store` 0.11 and `pyo3` 0.23.
 
 ### Breaking changes :wrench:
 

--- a/pyo3-object_store/CHANGELOG.md
+++ b/pyo3-object_store/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## [0.3.0] -
+## [0.3.0] - 2025-03-24
+
+Compatibility release to use `pyo3-object_store` with `object_store` 0.11.
 
 ### Breaking changes :wrench:
 

--- a/pyo3-object_store/Cargo.toml
+++ b/pyo3-object_store/Cargo.toml
@@ -22,7 +22,7 @@ futures = "0.3"
 humantime = "2.1"
 # This is already an object_store dependency
 itertools = "0.14.0"
-object_store = { version = "0.11", features = ["aws", "azure", "gcp", "http"] }
+object_store = { version = "0.12", features = ["aws", "azure", "gcp", "http"] }
 # This is already an object_store dependency
 percent-encoding = "2.1"
 pyo3 = { version = "0.24", features = ["chrono", "indexmap"] }

--- a/pyo3-object_store/Cargo.toml
+++ b/pyo3-object_store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-object_store"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Kyle Barron <kyle@developmentseed.org>"]
 edition = "2021"
 description = "object_store integration for pyo3."
@@ -22,11 +22,11 @@ futures = "0.3"
 humantime = "2.1"
 # This is already an object_store dependency
 itertools = "0.14.0"
-object_store = { version = "0.12", features = ["aws", "azure", "gcp", "http"] }
+object_store = { version = "0.11", features = ["aws", "azure", "gcp", "http"] }
 # This is already an object_store dependency
 percent-encoding = "2.1"
-pyo3 = { version = "0.24", features = ["chrono", "indexmap"] }
-pyo3-async-runtimes = { version = "0.24", features = ["tokio-runtime"] }
+pyo3 = { version = "0.23", features = ["chrono", "indexmap"] }
+pyo3-async-runtimes = { version = "0.23", features = ["tokio-runtime"] }
 serde = "1"
 thiserror = "1"
 tokio = { version = "1.40", features = ["rt-multi-thread"] }

--- a/pyo3-object_store/Cargo.toml
+++ b/pyo3-object_store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-object_store"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Kyle Barron <kyle@developmentseed.org>"]
 edition = "2021"
 description = "object_store integration for pyo3."
@@ -25,8 +25,8 @@ itertools = "0.14.0"
 object_store = { version = "0.11", features = ["aws", "azure", "gcp", "http"] }
 # This is already an object_store dependency
 percent-encoding = "2.1"
-pyo3 = { version = "0.23", features = ["chrono", "indexmap"] }
-pyo3-async-runtimes = { version = "0.23", features = ["tokio-runtime"] }
+pyo3 = { version = "0.24", features = ["chrono", "indexmap"] }
+pyo3-async-runtimes = { version = "0.24", features = ["tokio-runtime"] }
 serde = "1"
 thiserror = "1"
 tokio = { version = "1.40", features = ["rt-multi-thread"] }

--- a/pyo3-object_store/README.md
+++ b/pyo3-object_store/README.md
@@ -58,8 +58,11 @@ We don't yet have a _great_ solution here for reusing the store builder type hin
 
 ## Version compatibility
 
-| pyo3-object_store | pyo3 | object_store       |
-| ----------------- | ---- | ------------------ |
-| 0.1.x             | 0.23 | 0.12               |
-| 0.2.x             | 0.24 | 0.12               |
-| 0.3.x             | 0.23 | **0.11** :warning: |
+| pyo3-object_store | pyo3               | object_store       |
+| ----------------- | ------------------ | ------------------ |
+| 0.1.x             | 0.23               | 0.12               |
+| 0.2.x             | 0.24               | 0.12               |
+| 0.3.x             | **0.23** :warning: | **0.11** :warning: |
+| 0.4.x             | 0.24               | **0.11** :warning: |
+
+Note that 0.3.x and 0.4.x are compatibility releases to use `pyo3-object_store` with older versions of `pyo3` and `object_store`.

--- a/pyo3-object_store/README.md
+++ b/pyo3-object_store/README.md
@@ -58,7 +58,8 @@ We don't yet have a _great_ solution here for reusing the store builder type hin
 
 ## Version compatibility
 
-| pyo3-object_store | pyo3 | object_store |
-| ----------------- | ---- | ------------ |
-| 0.1.x             | 0.23 | 0.12         |
-| 0.2.x             | 0.24 | 0.12         |
+| pyo3-object_store | pyo3 | object_store       |
+| ----------------- | ---- | ------------------ |
+| 0.1.x             | 0.23 | 0.12               |
+| 0.2.x             | 0.24 | 0.12               |
+| 0.3.x             | 0.23 | **0.11** :warning: |

--- a/pyo3-object_store/src/prefix.rs
+++ b/pyo3-object_store/src/prefix.rs
@@ -144,7 +144,7 @@ impl<T: ObjectStore> ObjectStore for MaybePrefixedStore<T> {
         self.inner.get(&full_path).await
     }
 
-    async fn get_range(&self, location: &Path, range: Range<usize>) -> Result<Bytes> {
+    async fn get_range(&self, location: &Path, range: Range<u64>) -> Result<Bytes> {
         let full_path = self.full_path(location);
         self.inner.get_range(&full_path, range).await
     }
@@ -154,7 +154,7 @@ impl<T: ObjectStore> ObjectStore for MaybePrefixedStore<T> {
         self.inner.get_opts(&full_path, options).await
     }
 
-    async fn get_ranges(&self, location: &Path, ranges: &[Range<usize>]) -> Result<Vec<Bytes>> {
+    async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> Result<Vec<Bytes>> {
         let full_path = self.full_path(location);
         self.inner.get_ranges(&full_path, ranges).await
     }
@@ -170,7 +170,7 @@ impl<T: ObjectStore> ObjectStore for MaybePrefixedStore<T> {
         self.inner.delete(&full_path).await
     }
 
-    fn list(&self, prefix: Option<&Path>) -> BoxStream<'_, Result<ObjectMeta>> {
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, Result<ObjectMeta>> {
         let prefix = self.full_path(prefix.unwrap_or(DEFAULT_PATH.get_or_init(Path::default)));
         let s = self.inner.list(Some(&prefix));
         let slf_prefix = self.prefix.clone();
@@ -182,7 +182,7 @@ impl<T: ObjectStore> ObjectStore for MaybePrefixedStore<T> {
         &self,
         prefix: Option<&Path>,
         offset: &Path,
-    ) -> BoxStream<'_, Result<ObjectMeta>> {
+    ) -> BoxStream<'static, Result<ObjectMeta>> {
         let offset = self.full_path(offset);
         let prefix = self.full_path(prefix.unwrap_or(DEFAULT_PATH.get_or_init(Path::default)));
         let s = self.inner.list_with_offset(Some(&prefix), &offset);

--- a/pyo3-object_store/src/prefix.rs
+++ b/pyo3-object_store/src/prefix.rs
@@ -144,7 +144,7 @@ impl<T: ObjectStore> ObjectStore for MaybePrefixedStore<T> {
         self.inner.get(&full_path).await
     }
 
-    async fn get_range(&self, location: &Path, range: Range<u64>) -> Result<Bytes> {
+    async fn get_range(&self, location: &Path, range: Range<usize>) -> Result<Bytes> {
         let full_path = self.full_path(location);
         self.inner.get_range(&full_path, range).await
     }
@@ -154,7 +154,7 @@ impl<T: ObjectStore> ObjectStore for MaybePrefixedStore<T> {
         self.inner.get_opts(&full_path, options).await
     }
 
-    async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> Result<Vec<Bytes>> {
+    async fn get_ranges(&self, location: &Path, ranges: &[Range<usize>]) -> Result<Vec<Bytes>> {
         let full_path = self.full_path(location);
         self.inner.get_ranges(&full_path, ranges).await
     }
@@ -170,7 +170,7 @@ impl<T: ObjectStore> ObjectStore for MaybePrefixedStore<T> {
         self.inner.delete(&full_path).await
     }
 
-    fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, Result<ObjectMeta>> {
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'_, Result<ObjectMeta>> {
         let prefix = self.full_path(prefix.unwrap_or(DEFAULT_PATH.get_or_init(Path::default)));
         let s = self.inner.list(Some(&prefix));
         let slf_prefix = self.prefix.clone();
@@ -182,7 +182,7 @@ impl<T: ObjectStore> ObjectStore for MaybePrefixedStore<T> {
         &self,
         prefix: Option<&Path>,
         offset: &Path,
-    ) -> BoxStream<'static, Result<ObjectMeta>> {
+    ) -> BoxStream<'_, Result<ObjectMeta>> {
         let offset = self.full_path(offset);
         let prefix = self.full_path(prefix.unwrap_or(DEFAULT_PATH.get_or_init(Path::default)));
         let s = self.inner.list_with_offset(Some(&prefix), &offset);


### PR DESCRIPTION
Releases of `pyo3-object_store` were published from the https://github.com/developmentseed/obstore/tree/release/pyo3-object_store-v0.3 and https://github.com/developmentseed/obstore/tree/release/pyo3-object_store-v0.4 branches.

This updates the readme and changelog to reflect that.