### PR TITLE
Support anonymous GCS connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1393,8 +1393,8 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.12.0"
-source = "git+https://github.com/kylebarron/arrow-rs-object-store?rev=d1bd4fc8c05705c76a0145e38643bb6b2c267c11#d1bd4fc8c05705c76a0145e38643bb6b2c267c11"
+version = "0.12.1"
+source = "git+https://github.com/apache/arrow-rs-object-store?rev=ed9329f28eba5b1e0f6bbd10c79738ec42a9f568#ed9329f28eba5b1e0f6bbd10c79738ec42a9f568"
 dependencies = [
  "async-trait",
  "base64",
@@ -1424,6 +1424,8 @@ dependencies = [
  "tracing",
  "url",
  "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -1386,8 +1386,7 @@ dependencies = [
 [[package]]
 name = "object_store"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9ce831b09395f933addbc56d894d889e4b226eba304d4e7adbab591e26daf1e"
+source = "git+https://github.com/kylebarron/arrow-rs-object-store?rev=d1bd4fc8c05705c76a0145e38643bb6b2c267c11#d1bd4fc8c05705c76a0145e38643bb6b2c267c11"
 dependencies = [
  "async-trait",
  "base64",
@@ -1405,7 +1404,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "quick-xml",
- "rand",
+ "rand 0.9.0",
  "reqwest",
  "ring",
  "rustls-pemfile",
@@ -1517,7 +1516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1562,7 +1561,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -1756,7 +1755,7 @@ checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 dependencies = [
  "bytes",
  "getrandom 0.2.15",
- "rand",
+ "rand 0.8.5",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1798,8 +1797,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -1809,7 +1819,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1819,6 +1839,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.1",
 ]
 
 [[package]]
@@ -2814,7 +2843,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+dependencies = [
+ "zerocopy-derive 0.8.24",
 ]
 
 [[package]]
@@ -2822,6 +2860,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,4 +39,5 @@ lto = true
 codegen-units = 1
 
 [patch.crates-io]
-object_store = { git = 'https://github.com/kylebarron/arrow-rs-object-store', rev = "d1bd4fc8c05705c76a0145e38643bb6b2c267c11" }
+# 0.12.1 rc
+object_store = { git = 'https://github.com/apache/arrow-rs-object-store', rev = "ed9329f28eba5b1e0f6bbd10c79738ec42a9f568" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,6 @@ url = "2"
 [profile.release]
 lto = true
 codegen-units = 1
+
+[patch.crates-io]
+object_store = { git = 'https://github.com/kylebarron/arrow-rs-object-store', rev = "d1bd4fc8c05705c76a0145e38643bb6b2c267c11" }

--- a/obstore/Cargo.toml
+++ b/obstore/Cargo.toml
@@ -45,6 +45,3 @@ url = { workspace = true }
 reqwest = { version = "*", default-features = false, features = [
     "rustls-tls-native-roots",
 ] }
-
-[patch.crates-io]
-object_store = { git = 'https://github.com/kylebarron/arrow-rs-object-store', rev = "d1bd4fc8c05705c76a0145e38643bb6b2c267c11" }

--- a/obstore/Cargo.toml
+++ b/obstore/Cargo.toml
@@ -45,3 +45,6 @@ url = { workspace = true }
 reqwest = { version = "*", default-features = false, features = [
     "rustls-tls-native-roots",
 ] }
+
+[patch.crates-io]
+object_store = { git = 'https://github.com/kylebarron/arrow-rs-object-store', rev = "d1bd4fc8c05705c76a0145e38643bb6b2c267c11" }

--- a/obstore/python/obstore/_store/_gcs.pyi
+++ b/obstore/python/obstore/_store/_gcs.pyi
@@ -74,6 +74,14 @@ class GCSConfig(TypedDict, total=False):
     **Environment variable**: `GOOGLE_APPLICATION_CREDENTIALS`.
     """
 
+    skip_signature: bool
+    """If `True`, GCSStore will not fetch credentials and will not sign requests.
+
+    This can be useful when interacting with public GCS buckets that deny authorized requests.
+
+    **Environment variable**: `GOOGLE_SKIP_SIGNATURE`.
+    """
+
 class GCSCredential(TypedDict):
     """A Google Cloud Storage Credential.
 


### PR DESCRIPTION
Relies on this upstream PR: https://github.com/apache/arrow-rs-object-store/pull/322

Closes #416

Bumps to 0.12.1 release candidate.