### PR TITLE
Bump pyo3-file and avoid extra GIL acquire

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1667,9 +1667,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-file"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7fc1b57b1e7e2047d0907ded8086866ba8390a8b0ba512bcc35ececbffed72a"
+checksum = "8d97fbb05588c29774af01833e598fae7e714a3f87d36b286e0466f6b678e4a7"
 dependencies = [
  "pyo3",
  "skeptic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ indexmap = "2"
 object_store = "0.12"
 pyo3 = { version = "0.24", features = ["macros", "indexmap"] }
 pyo3-async-runtimes = { version = "0.24", features = ["tokio-runtime"] }
-pyo3-file = "0.11"
+pyo3-file = "0.12"
 thiserror = "1"
 tokio = "1.40"
 url = "2"

--- a/obstore/src/put.rs
+++ b/obstore/src/put.rs
@@ -249,7 +249,7 @@ impl<'py> FromPyObject<'py> for PutInput {
         // Check for file-like object
         else if ob.hasattr(intern!(py, "read"))? && ob.hasattr(intern!(py, "seek"))? {
             Ok(Self::Pull(PullSource::FileLike(
-                PyFileLikeObject::with_requirements(ob.clone().unbind(), true, false, true, false)?,
+                PyFileLikeObject::py_with_requirements(ob.clone(), true, false, true, false)?,
             )))
         }
         // Ensure we check _first_ for an async generator before a sync one


### PR DESCRIPTION
See https://docs.rs/pyo3-file/latest/pyo3_file/struct.PyFileLikeObject.html#method.py_with_requirements. 

> Prefer using this instead of [with_requirements](https://docs.rs/pyo3-file/latest/pyo3_file/struct.PyFileLikeObject.html#method.with_requirements) if you already have a Bound<PyAny> object, as this method does not acquire the GIL internally.