### PR TITLE
Include `object_store` version and source in Python dist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,6 +373,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-lock"
+version = "10.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06acb4f71407ba205a07cb453211e0e6a67b21904e47f6ba1f9589e38f2e454"
+dependencies = [
+ "semver",
+ "serde",
+ "toml",
+ "url",
+]
+
+[[package]]
 name = "cargo-platform"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1425,6 +1437,7 @@ version = "0.6.0"
 dependencies = [
  "arrow",
  "bytes",
+ "cargo-lock",
  "chrono",
  "futures",
  "http",
@@ -2115,6 +2128,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2369,6 +2391,40 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -2761,6 +2817,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/obstore/Cargo.toml
+++ b/obstore/Cargo.toml
@@ -45,3 +45,6 @@ url = { workspace = true }
 reqwest = { version = "*", default-features = false, features = [
     "rustls-tls-native-roots",
 ] }
+
+[build-dependencies]
+cargo-lock = "10.1.0"

--- a/obstore/build.rs
+++ b/obstore/build.rs
@@ -1,0 +1,47 @@
+use cargo_lock::{Lockfile, SourceId, Version};
+use std::ffi::OsString;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+use std::{env, io};
+
+fn main() {
+    let lockfile_location = get_lockfile_location().unwrap();
+    let (version, source) = read_lockfile(&lockfile_location);
+
+    println!("cargo:rustc-env=OBJECT_STORE_VERSION={}", version);
+    println!(
+        "cargo:rustc-env=OBJECT_STORE_SOURCE={}",
+        source.map(|s| s.to_string()).unwrap_or("".to_string())
+    );
+}
+
+fn get_lockfile_location() -> io::Result<PathBuf> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+
+    let cargo_lock = OsString::from("Cargo.lock");
+
+    for ancestor in path.as_path().ancestors() {
+        for entry in ancestor.read_dir()? {
+            let entry = entry?;
+            if entry.file_name() == cargo_lock {
+                return Ok(entry.path());
+            }
+        }
+    }
+
+    Err(io::Error::new(
+        ErrorKind::NotFound,
+        "Ran out of places to find Cargo.toml",
+    ))
+}
+
+fn read_lockfile(path: &Path) -> (Version, Option<SourceId>) {
+    let lockfile = Lockfile::load(path).unwrap();
+    let idx = lockfile
+        .packages
+        .iter()
+        .position(|p| p.name.as_str() == "object_store")
+        .unwrap();
+    let package = &lockfile.packages[idx];
+    (package.version.clone(), package.source.clone())
+}

--- a/obstore/python/obstore/__init__.py
+++ b/obstore/python/obstore/__init__.py
@@ -2,12 +2,10 @@ from typing import TYPE_CHECKING
 
 from . import _obstore, store
 from ._obstore import *  # noqa: F403
-from ._obstore import ___version
 
 if TYPE_CHECKING:
     from . import exceptions  # noqa: TC004
 
-__version__: str = ___version()
 
-__all__ = ["__version__", "exceptions", "store"]
+__all__ = ["exceptions", "store"]
 __all__ += _obstore.__all__

--- a/obstore/python/obstore/_obstore.pyi
+++ b/obstore/python/obstore/_obstore.pyi
@@ -41,7 +41,9 @@ from ._rename import rename, rename_async
 from ._scheme import parse_scheme
 from ._sign import HTTP_METHOD, SignCapableStore, sign, sign_async
 
-def ___version() -> str: ...
+__version__: str
+_object_store_version: str
+_object_store_source: str
 
 __all__ = [
     "HTTP_METHOD",
@@ -65,6 +67,9 @@ __all__ = [
     "SuffixRange",
     "UpdateVersion",
     "WritableFile",
+    "__version__",
+    "_object_store_source",
+    "_object_store_version",
     "_store",
     "copy",
     "copy_async",

--- a/obstore/src/lib.rs
+++ b/obstore/src/lib.rs
@@ -20,11 +20,8 @@ mod utils;
 use pyo3::prelude::*;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
-
-#[pyfunction]
-fn ___version() -> &'static str {
-    VERSION
-}
+const OBJECT_STORE_VERSION: &str = env!("OBJECT_STORE_VERSION");
+const OBJECT_STORE_SOURCE: &str = env!("OBJECT_STORE_SOURCE");
 
 /// Raise RuntimeWarning for debug builds
 #[pyfunction]
@@ -51,7 +48,9 @@ fn check_debug_build(_py: Python) -> PyResult<()> {
 fn _obstore(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     check_debug_build(py)?;
 
-    m.add_wrapped(wrap_pyfunction!(___version))?;
+    m.add("__version__", VERSION)?;
+    m.add("_object_store_version", OBJECT_STORE_VERSION)?;
+    m.add("_object_store_source", OBJECT_STORE_SOURCE)?;
 
     pyo3_object_store::register_store_module(py, m, "obstore", "_store")?;
     pyo3_object_store::register_exceptions_module(py, m, "obstore", "exceptions")?;

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,7 @@
+from obstore import __version__, _object_store_source, _object_store_version
+
+
+def test_versions_are_str():
+    assert isinstance(__version__, str)
+    assert isinstance(_object_store_version, str)
+    assert isinstance(_object_store_source, str)


### PR DESCRIPTION
For now, we'll export these as private attributes, and we can direct people to check them as necessary in bug reports. But since the underlying `object_store` isn't changing very often, and since it's statically compiled in wheels, ideally we won't need to add these to our public API

Closes #405 