### PR TITLE
fix: docs for json.loads(bytes)

### DIFF
--- a/obstore/python/obstore/store.py
+++ b/obstore/python/obstore/store.py
@@ -551,7 +551,8 @@ class HTTPStore(_ObjectStoreMixin, _store.HTTPStore):
     store = HTTPStore.from_url("https://api.github.com")
     resp = obs.get(store, "repos/developmentseed/obstore")
 
-    # If you have orjson installed, you can load bytes without copying them via `memoryview`:
+    # If you have orjson installed, you can load bytes without copying them via
+    # `memoryview`:
     import orjson
     data = orjson.loads(memoryview(resp.bytes()))
 


### PR DESCRIPTION
The docs indicate that you can `json.loads(bytes)` but you can't. I've ~added a failing test to demonstrate, and~ corrected the docs. ~Not sure if we _should_ be able to `json.loads`?~