### PR TITLE
Add missing "Not importable at runtime" warnings to docs

### DIFF
--- a/obstore/python/obstore/_attributes.pyi
+++ b/obstore/python/obstore/_attributes.pyi
@@ -41,6 +41,17 @@ Attribute: TypeAlias = (
     See [Cache-Control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control).
 
 Any other string key specifies a user-defined metadata field for the object.
+
+!!! warning "Not importable at runtime"
+
+    To use this type hint in your code, import it within a `TYPE_CHECKING` block:
+
+    ```py
+    from __future__ import annotations
+    from typing import TYPE_CHECKING
+    if TYPE_CHECKING:
+        from obstore import Attribute
+    ```
 """
 
 Attributes: TypeAlias = dict[Attribute, str]
@@ -50,4 +61,15 @@ Attributes can be specified in [`put`][obstore.put]/[`put_async`][obstore.put_as
 retrieved from [`get`][obstore.get]/[`get_async`][obstore.get_async].
 
 Unlike ObjectMeta, Attributes are not returned by listing APIs
+
+!!! warning "Not importable at runtime"
+
+    To use this type hint in your code, import it within a `TYPE_CHECKING` block:
+
+    ```py
+    from __future__ import annotations
+    from typing import TYPE_CHECKING
+    if TYPE_CHECKING:
+        from obstore import Attributes
+    ```
 """

--- a/obstore/python/obstore/_buffered.pyi
+++ b/obstore/python/obstore/_buffered.pyi
@@ -68,6 +68,17 @@ class ReadableFile:
     [`get_ranges`][obstore.get_ranges], which will optimise the vectored IO.
 
     [high first-byte latencies]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance.html
+
+    !!! warning "Not importable at runtime"
+
+        To use this type hint in your code, import it within a `TYPE_CHECKING` block:
+
+        ```py
+        from __future__ import annotations
+        from typing import TYPE_CHECKING
+        if TYPE_CHECKING:
+            from obstore import ReadableFile
+        ```
     """  # noqa: D205
 
     def close(self) -> None:
@@ -139,6 +150,17 @@ class AsyncReadableFile:
     [`get_ranges`][obstore.get_ranges], which will optimise the vectored IO.
 
     [high first-byte latencies]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance.html
+
+    !!! warning "Not importable at runtime"
+
+        To use this type hint in your code, import it within a `TYPE_CHECKING` block:
+
+        ```py
+        from __future__ import annotations
+        from typing import TYPE_CHECKING
+        if TYPE_CHECKING:
+            from obstore import AsyncReadableFile
+        ```
     """  # noqa: D205
 
     def close(self) -> None:
@@ -234,6 +256,17 @@ class WritableFile(AbstractContextManager):
 
     This implements a similar interface as a Python
     [`BufferedWriter`][io.BufferedWriter].
+
+    !!! warning "Not importable at runtime"
+
+        To use this type hint in your code, import it within a `TYPE_CHECKING` block:
+
+        ```py
+        from __future__ import annotations
+        from typing import TYPE_CHECKING
+        if TYPE_CHECKING:
+            from obstore import WritableFile
+        ```
     """
 
     def __enter__(self) -> Self: ...
@@ -254,7 +287,19 @@ class WritableFile(AbstractContextManager):
         """Write the [bytes-like object](https://docs.python.org/3/glossary.html#term-bytes-like-object), `buffer`, and return the number of bytes written."""
 
 class AsyncWritableFile(AbstractAsyncContextManager):
-    """A buffered writable file object with **asynchronous** operations."""
+    """A buffered writable file object with **asynchronous** operations.
+
+    !!! warning "Not importable at runtime"
+
+        To use this type hint in your code, import it within a `TYPE_CHECKING` block:
+
+        ```py
+        from __future__ import annotations
+        from typing import TYPE_CHECKING
+        if TYPE_CHECKING:
+            from obstore import AsyncWritableFile
+        ```
+    """
 
     async def __aenter__(self) -> Self: ...
     async def __aexit__(self, exc_type, exc_value, traceback) -> None: ...  # noqa: ANN001

--- a/obstore/python/obstore/_get.pyi
+++ b/obstore/python/obstore/_get.pyi
@@ -8,13 +8,37 @@ from ._list import ObjectMeta
 from .store import ObjectStore
 
 class OffsetRange(TypedDict):
-    """Request all bytes starting from a given byte offset."""
+    """Request all bytes starting from a given byte offset.
+
+    !!! warning "Not importable at runtime"
+
+        To use this type hint in your code, import it within a `TYPE_CHECKING` block:
+
+        ```py
+        from __future__ import annotations
+        from typing import TYPE_CHECKING
+        if TYPE_CHECKING:
+            from obstore import OffsetRange
+        ```
+    """
 
     offset: int
     """The byte offset for the offset range request."""
 
 class SuffixRange(TypedDict):
-    """Request up to the last `n` bytes."""
+    """Request up to the last `n` bytes.
+
+    !!! warning "Not importable at runtime"
+
+        To use this type hint in your code, import it within a `TYPE_CHECKING` block:
+
+        ```py
+        from __future__ import annotations
+        from typing import TYPE_CHECKING
+        if TYPE_CHECKING:
+            from obstore import SuffixRange
+        ```
+    """
 
     suffix: int
     """The number of bytes from the suffix to request."""
@@ -23,6 +47,17 @@ class GetOptions(TypedDict, total=False):
     """Options for a get request.
 
     All options are optional.
+
+    !!! warning "Not importable at runtime"
+
+        To use this type hint in your code, import it within a `TYPE_CHECKING` block:
+
+        ```py
+        from __future__ import annotations
+        from typing import TYPE_CHECKING
+        if TYPE_CHECKING:
+            from obstore import GetOptions
+        ```
     """
 
     if_match: str | None
@@ -124,6 +159,17 @@ class GetResult:
 
     Note that after calling `bytes`, `bytes_async`, or `stream`, you will no longer be
     able to call other methods on this object, such as the `meta` attribute.
+
+    !!! warning "Not importable at runtime"
+
+        To use this type hint in your code, import it within a `TYPE_CHECKING` block:
+
+        ```py
+        from __future__ import annotations
+        from typing import TYPE_CHECKING
+        if TYPE_CHECKING:
+            from obstore import GetResult
+        ```
     """
 
     @property
@@ -211,6 +257,17 @@ class BytesStream:
 
         To fix this, set the `timeout` parameter in the
         [`client_options`][obstore.store.ClientConfig] passed when creating the store.
+
+    !!! warning "Not importable at runtime"
+
+        To use this type hint in your code, import it within a `TYPE_CHECKING` block:
+
+        ```py
+        from __future__ import annotations
+        from typing import TYPE_CHECKING
+        if TYPE_CHECKING:
+            from obstore import BytesStream
+        ```
     """
 
     def __aiter__(self) -> BytesStream:

--- a/obstore/python/obstore/_list.pyi
+++ b/obstore/python/obstore/_list.pyi
@@ -14,7 +14,19 @@ else:
     from typing_extensions import Self
 
 class ObjectMeta(TypedDict):
-    """The metadata that describes an object."""
+    """The metadata that describes an object.
+
+    !!! warning "Not importable at runtime"
+
+        To use this type hint in your code, import it within a `TYPE_CHECKING` block:
+
+        ```py
+        from __future__ import annotations
+        from typing import TYPE_CHECKING
+        if TYPE_CHECKING:
+            from obstore import ObjectMeta
+        ```
+    """
 
     path: str
     """The full path to the object"""
@@ -39,6 +51,17 @@ ListChunkType = TypeVar("ListChunkType", List[ObjectMeta], RecordBatch, Table)  
 By default, listing APIs return a `list` of [`ObjectMeta`][obstore.ObjectMeta]. However
 for improved performance when listing large buckets, you can pass `return_arrow=True`.
 Then an Arrow `RecordBatch` will be returned instead.
+
+!!! warning "Not importable at runtime"
+
+    To use this type hint in your code, import it within a `TYPE_CHECKING` block:
+
+    ```py
+    from __future__ import annotations
+    from typing import TYPE_CHECKING
+    if TYPE_CHECKING:
+        from obstore import ListChunkType
+    ```
 """
 
 class ListResult(TypedDict, Generic[ListChunkType]):
@@ -49,6 +72,17 @@ class ListResult(TypedDict, Generic[ListChunkType]):
     object storage's limitations.
 
     This implements [`obstore.ListResult`][].
+
+    !!! warning "Not importable at runtime"
+
+        To use this type hint in your code, import it within a `TYPE_CHECKING` block:
+
+        ```py
+        from __future__ import annotations
+        from typing import TYPE_CHECKING
+        if TYPE_CHECKING:
+            from obstore import ListResult
+        ```
     """
 
     common_prefixes: List[str]
@@ -62,6 +96,17 @@ class ListStream(Generic[ListChunkType]):
     async fashion.
 
     This implements [`obstore.ListStream`][].
+
+    !!! warning "Not importable at runtime"
+
+        To use this type hint in your code, import it within a `TYPE_CHECKING` block:
+
+        ```py
+        from __future__ import annotations
+        from typing import TYPE_CHECKING
+        if TYPE_CHECKING:
+            from obstore import ListStream
+        ```
     """  # noqa: D205
 
     def __aiter__(self) -> Self:

--- a/obstore/python/obstore/_put.pyi
+++ b/obstore/python/obstore/_put.pyi
@@ -21,6 +21,17 @@ class UpdateVersion(TypedDict, total=False):
 
     Stores will use differing combinations of `e_tag` and `version` to provide
     conditional updates, and it is therefore recommended applications preserve both
+
+    !!! warning "Not importable at runtime"
+
+        To use this type hint in your code, import it within a `TYPE_CHECKING` block:
+
+        ```py
+        from __future__ import annotations
+        from typing import TYPE_CHECKING
+        if TYPE_CHECKING:
+            from obstore import UpdateVersion
+        ```
     """
 
     e_tag: str | None
@@ -47,10 +58,33 @@ If a string is provided, it must be one of:
 - `"create"`
 If a `dict` is provided, it must meet the criteria of
 [`UpdateVersion`][obstore.UpdateVersion].
+
+!!! warning "Not importable at runtime"
+
+    To use this type hint in your code, import it within a `TYPE_CHECKING` block:
+
+    ```py
+    from __future__ import annotations
+    from typing import TYPE_CHECKING
+    if TYPE_CHECKING:
+        from obstore import PutMode
+    ```
 """
 
 class PutResult(TypedDict):
-    """Result for a put request."""
+    """Result for a put request.
+
+    !!! warning "Not importable at runtime"
+
+        To use this type hint in your code, import it within a `TYPE_CHECKING` block:
+
+        ```py
+        from __future__ import annotations
+        from typing import TYPE_CHECKING
+        if TYPE_CHECKING:
+            from obstore import PutResult
+        ```
+    """
 
     e_tag: str | None
     """


### PR DESCRIPTION
## Available PR templates

<!--
  Github doesn't allow PR template selection the same way that it is possible with issues.
  Preview this and select the appropriate template
-->

- [Default](?expand=1&template=default.md)
- [Version Release](?expand=1&template=version_release.md)
- _Alternatively delete and start empty_
