### PR TITLE
Enable accessing `meta`, `range`, and `attributes` after reading `GetResult` payload

### DIFF
--- a/obstore/python/obstore/_get.pyi
+++ b/obstore/python/obstore/_get.pyi
@@ -157,9 +157,6 @@ class GetResult:
         print(len(buf))
     ```
 
-    Note that after calling `bytes`, `bytes_async`, or `stream`, you will no longer be
-    able to call other methods on this object, such as the `meta` attribute.
-
     !!! warning "Not importable at runtime"
 
         To use this type hint in your code, import it within a `TYPE_CHECKING` block:
@@ -174,10 +171,7 @@ class GetResult:
 
     @property
     def attributes(self) -> Attributes:
-        """Additional object attributes.
-
-        This must be accessed _before_ calling `stream`, `bytes`, or `bytes_async`.
-        """
+        """Additional object attributes."""
 
     def bytes(self) -> Bytes:
         """Collect the data into a `Bytes` object.
@@ -195,18 +189,13 @@ class GetResult:
 
     @property
     def meta(self) -> ObjectMeta:
-        """The ObjectMeta for this object.
-
-        This must be accessed _before_ calling `stream`, `bytes`, or `bytes_async`.
-        """
+        """The ObjectMeta for this object."""
 
     @property
     def range(self) -> tuple[int, int]:
         """The range of bytes returned by this request.
 
         Note that this is `(start, stop)` **not** `(start, length)`.
-
-        This must be accessed _before_ calling `stream`, `bytes`, or `bytes_async`.
         """
 
     def stream(self, min_chunk_size: int = 10 * 1024 * 1024) -> BytesStream:

--- a/obstore/src/get.rs
+++ b/obstore/src/get.rs
@@ -6,7 +6,7 @@ use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use futures::stream::{BoxStream, Fuse};
 use futures::StreamExt;
-use object_store::{GetOptions, GetRange, GetResult, ObjectStore};
+use object_store::{Attributes, GetOptions, GetRange, GetResult, ObjectMeta, ObjectStore};
 use pyo3::exceptions::{PyStopAsyncIteration, PyStopIteration, PyValueError};
 use pyo3::prelude::*;
 use pyo3_bytes::PyBytes;
@@ -98,8 +98,6 @@ impl From<PySuffixRange> for GetRange {
 
 pub(crate) struct PyGetRange(GetRange);
 
-// TODO: think of a better API here so that the distinction between each of these is easy to
-// understand.
 // Allowed input:
 // - [usize, usize] to refer to a bounded range from start to end (exclusive)
 // - {"offset": usize} to request all bytes starting from a given byte offset
@@ -118,12 +116,31 @@ impl<'py> FromPyObject<'py> for PyGetRange {
     }
 }
 
+/// Note that we clone the [ObjectMeta], byte range, and [Attributes] from the [`GetResult`] so
+/// that we can access them from Python even after the result has been disposed.
 #[pyclass(name = "GetResult", frozen)]
-pub(crate) struct PyGetResult(std::sync::Mutex<Option<GetResult>>);
+pub(crate) struct PyGetResult {
+    /// The [`ObjectMeta`] for this object
+    meta: ObjectMeta,
+    /// The range of bytes returned by this request
+    range: Range<u64>,
+    /// Additional object attributes
+    attributes: Attributes,
+    /// The underlying result
+    result: std::sync::Mutex<Option<GetResult>>,
+}
 
 impl PyGetResult {
     fn new(result: GetResult) -> Self {
-        Self(std::sync::Mutex::new(Some(result)))
+        // Note: in the future we could avoid these clones if we stored GetResultPayload directly,
+        // but it's useful to use the upstream helper methods defined on `GetResult`, like
+        // `GetResult::bytes` and `GetResult::into_stream`.
+        Self {
+            meta: result.meta.clone(),
+            range: result.range.clone(),
+            attributes: result.attributes.clone(),
+            result: std::sync::Mutex::new(Some(result)),
+        }
     }
 }
 
@@ -131,7 +148,7 @@ impl PyGetResult {
 impl PyGetResult {
     fn bytes(&self, py: Python) -> PyObjectStoreResult<PyBytes> {
         let get_result = self
-            .0
+            .result
             .lock()
             .unwrap()
             .take()
@@ -145,7 +162,7 @@ impl PyGetResult {
 
     fn bytes_async<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let get_result = self
-            .0
+            .result
             .lock()
             .unwrap()
             .take()
@@ -161,36 +178,23 @@ impl PyGetResult {
 
     #[getter]
     fn attributes(&self) -> PyResult<PyAttributes> {
-        let inner = self.0.lock().unwrap();
-        let inner = inner
-            .as_ref()
-            .ok_or(PyValueError::new_err("Result has already been disposed."))?;
-        Ok(PyAttributes::new(inner.attributes.clone()))
+        Ok(PyAttributes::new(self.attributes.clone()))
     }
 
     #[getter]
     fn meta(&self) -> PyResult<PyObjectMeta> {
-        let inner = self.0.lock().unwrap();
-        let inner = inner
-            .as_ref()
-            .ok_or(PyValueError::new_err("Result has already been disposed."))?;
-        Ok(PyObjectMeta::new(inner.meta.clone()))
+        Ok(PyObjectMeta::new(self.meta.clone()))
     }
 
     #[getter]
     fn range(&self) -> PyResult<(u64, u64)> {
-        let inner = self.0.lock().unwrap();
-        let range = &inner
-            .as_ref()
-            .ok_or(PyValueError::new_err("Result has already been disposed."))?
-            .range;
-        Ok((range.start, range.end))
+        Ok((self.range.start, self.range.end))
     }
 
     #[pyo3(signature = (min_chunk_size = DEFAULT_BYTES_CHUNK_SIZE))]
     fn stream(&self, min_chunk_size: usize) -> PyResult<PyBytesStream> {
         let get_result = self
-            .0
+            .result
             .lock()
             .unwrap()
             .take()

--- a/obstore/src/get.rs
+++ b/obstore/src/get.rs
@@ -135,6 +135,7 @@ impl PyGetResult {
         // Note: in the future we could avoid these clones if we stored GetResultPayload directly,
         // but it's useful to use the upstream helper methods defined on `GetResult`, like
         // `GetResult::bytes` and `GetResult::into_stream`.
+        // Once https://github.com/apache/arrow-rs-object-store/pull/353 is merged it'll be easier.
         Self {
             meta: result.meta.clone(),
             range: result.range.clone(),

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -168,3 +168,18 @@ def test_get_ranges_invalid_range():
 
     with pytest.raises(ValueError, match="Invalid range"):
         store.get_ranges(path, starts=[10, 20], lengths=[10, 0])
+
+
+def test_access_getresult_attributes_after_reading_stream():
+    store = MemoryStore()
+
+    data = b"the quick brown fox jumps over the lazy dog," * 100
+    path = "data.txt"
+    store.put(path, data)
+
+    resp = store.get(path)
+
+    _buffer = resp.bytes()
+    # Validate that we can access the range _after_ consuming the buffer
+    r = resp.range
+    assert r == (0, 4400)


### PR DESCRIPTION
Closes https://github.com/developmentseed/obstore/issues/439

We can avoid the clones if/once https://github.com/apache/arrow-rs-object-store/pull/353 is merged.