### PR TITLE
Limit public methods on `obstore.auth.AzureCredentialProvider`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Breaking changes :wrench:
+
+- `obstore.auth.AzureCredentialProvider` (and `obstore.auth.AzureAsyncCredentialProvider`) removed some attributes that were previously accidentally public. Also, `scopes` and `tenant_id` parameters in the `__init__` of those two classes are now keyword-only parameters.
+
 ## [0.6.0] - 2025-03-24
 
 ### New Features :magic_wand:

--- a/obstore/python/obstore/auth/azure.py
+++ b/obstore/python/obstore/auth/azure.py
@@ -61,6 +61,7 @@ class AzureCredentialProvider:
         | azure.identity.WorkloadIdentityCredential
         | None = None,
         scopes: Iterable[str] = DEFAULT_SCOPES,
+        *,
         tenant_id: str | None = None,
     ) -> None:
         """Create a new AzureCredentialProvider.
@@ -76,20 +77,20 @@ class AzureCredentialProvider:
         [`azure.identity.DefaultAzureCredential`]: https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential
 
         """
-        self.credential = credential or azure.identity.DefaultAzureCredential()
-        self.scopes = scopes
-        self.tenant_id = tenant_id
+        self._credential = credential or azure.identity.DefaultAzureCredential()
+        self._scopes = scopes
+        self._tenant_id = tenant_id
 
     def __call__(self) -> AzureCredential:
         """Fetch the credential."""
-        self.token = self.credential.get_token(
-            *self.scopes,
-            tenant_id=self.tenant_id,
+        token = self._credential.get_token(
+            *self._scopes,
+            tenant_id=self._tenant_id,
         )
 
         return {
-            "token": self.token.token,
-            "expires_at": datetime.fromtimestamp(self.token.expires_on, timezone.utc),
+            "token": token.token,
+            "expires_at": datetime.fromtimestamp(token.expires_on, timezone.utc),
         }
 
 
@@ -138,6 +139,7 @@ class AzureAsyncCredentialProvider:
         | azure.identity.aio.WorkloadIdentityCredential
         | None = None,
         scopes: Iterable[str] = DEFAULT_SCOPES,
+        *,
         tenant_id: str | None = None,
     ) -> None:
         """Create a new AzureAsyncCredentialProvider.
@@ -153,18 +155,18 @@ class AzureAsyncCredentialProvider:
         [`azure.identity.aio.DefaultAzureCredential`]: https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.aio.defaultazurecredential
 
         """
-        self.credential = credential or azure.identity.aio.DefaultAzureCredential()
-        self.scopes = scopes
-        self.tenant_id = tenant_id
+        self._credential = credential or azure.identity.aio.DefaultAzureCredential()
+        self._scopes = scopes
+        self._tenant_id = tenant_id
 
     async def __call__(self) -> AzureCredential:
         """Fetch the credential."""
-        self.token = await self.credential.get_token(
-            *self.scopes,
-            tenant_id=self.tenant_id,
+        token = await self._credential.get_token(
+            *self._scopes,
+            tenant_id=self._tenant_id,
         )
 
         return {
-            "token": self.token.token,
-            "expires_at": datetime.fromtimestamp(self.token.expires_on, timezone.utc),
+            "token": token.token,
+            "expires_at": datetime.fromtimestamp(token.expires_on, timezone.utc),
         }

--- a/obstore/python/obstore/auth/azure.py
+++ b/obstore/python/obstore/auth/azure.py
@@ -60,8 +60,8 @@ class AzureCredentialProvider:
         | azure.identity.VisualStudioCodeCredential
         | azure.identity.WorkloadIdentityCredential
         | None = None,
-        scopes: Iterable[str] = DEFAULT_SCOPES,
         *,
+        scopes: Iterable[str] = DEFAULT_SCOPES,
         tenant_id: str | None = None,
     ) -> None:
         """Create a new AzureCredentialProvider.
@@ -70,6 +70,8 @@ class AzureCredentialProvider:
             credential: Credential to use for this provider. Defaults to `None`,
                 in which case [`azure.identity.DefaultAzureCredential`][] will be
                 called to find default credentials.
+
+        Other Args:
             scopes: Scopes required by the access token.
             tenant_id: Optionally specify the Azure Tenant ID which will be passed to
                 the credential's `get_token` method.
@@ -138,8 +140,8 @@ class AzureAsyncCredentialProvider:
         | azure.identity.aio.VisualStudioCodeCredential
         | azure.identity.aio.WorkloadIdentityCredential
         | None = None,
-        scopes: Iterable[str] = DEFAULT_SCOPES,
         *,
+        scopes: Iterable[str] = DEFAULT_SCOPES,
         tenant_id: str | None = None,
     ) -> None:
         """Create a new AzureAsyncCredentialProvider.
@@ -148,6 +150,8 @@ class AzureAsyncCredentialProvider:
             credential: Credential to use for this provider. Defaults to `None`,
                 in which case [`azure.identity.aio.DefaultAzureCredential`][] will be
                 called to find default credentials.
+
+        Other Args:
             scopes: Scopes required by the access token.
             tenant_id: Optionally specify the Azure Tenant ID which will be passed to
                 the credential's `get_token` method.


### PR DESCRIPTION
This was an oversight of mine in the initial PR to add the `AzureCredentialProvider` in https://github.com/developmentseed/obstore/pull/343 (cc @daviewales)

## Change list

- Remove some attributes from `obstore.auth.AzureCredentialProvider` and `obstore.auth.AzureAsyncCredentialProvider` that were previously accidentally public. 
- `scopes` and `tenant_id` parameters in the `__init__` of those two classes are now keyword-only parameters.