### PR TITLE
Remove `@staticmethod` from credential provider type annotations

### DIFF
--- a/obstore/python/obstore/_store/_aws.pyi
+++ b/obstore/python/obstore/_store/_aws.pyi
@@ -451,8 +451,7 @@ class S3CredentialProvider(Protocol):
         ```
     """
 
-    @staticmethod
-    def __call__() -> S3Credential | Coroutine[Any, Any, S3Credential]:
+    def __call__(self) -> S3Credential | Coroutine[Any, Any, S3Credential]:
         """Return an `S3Credential`."""
 
 class S3Store:

--- a/obstore/python/obstore/_store/_azure.pyi
+++ b/obstore/python/obstore/_store/_azure.pyi
@@ -313,8 +313,7 @@ class AzureCredentialProvider(Protocol):
         ```
     """
 
-    @staticmethod
-    def __call__() -> AzureCredential | Coroutine[Any, Any, AzureCredential]:
+    def __call__(self) -> AzureCredential | Coroutine[Any, Any, AzureCredential]:
         """Return an `AzureCredential`."""
 
 class AzureStore:

--- a/obstore/python/obstore/_store/_gcs.pyi
+++ b/obstore/python/obstore/_store/_gcs.pyi
@@ -123,8 +123,7 @@ class GCSCredentialProvider(Protocol):
         ```
     """
 
-    @staticmethod
-    def __call__() -> GCSCredential | Coroutine[Any, Any, GCSCredential]:
+    def __call__(self) -> GCSCredential | Coroutine[Any, Any, GCSCredential]:
         """Return a `GCSCredential`."""
 
 class GCSStore:


### PR DESCRIPTION
See similar discussion [here](https://github.com/zarr-developers/VirtualiZarr/pull/568#discussion_r2085085770). This is equivalent in the type system (and not a breaking change) but the semantics may align slightly better with what we want and the [docs on callback protocols](https://typing.python.org/en/latest/spec/callables.html#callback-protocols) suggest including `self` as a parameter.