### PR TITLE
Don't use an enum for PyExternalObjectStoreInner

### DIFF
--- a/pyo3-bytes/src/bytes.rs
+++ b/pyo3-bytes/src/bytes.rs
@@ -461,7 +461,7 @@ fn validate_buffer(buf: &PyBuffer<u8>) -> PyResult<()> {
         return Err(PyValueError::new_err("Buffer is not C contiguous"));
     }
 
-    if buf.strides().iter().any(|s| *s == 0) {
+    if buf.strides().iter().any(|s| *s != 0) {
         return Err(PyValueError::new_err("Non-zero strides not supported."));
     }
 

--- a/pyo3-bytes/src/bytes.rs
+++ b/pyo3-bytes/src/bytes.rs
@@ -461,8 +461,11 @@ fn validate_buffer(buf: &PyBuffer<u8>) -> PyResult<()> {
         return Err(PyValueError::new_err("Buffer is not C contiguous"));
     }
 
-    if buf.strides().iter().any(|s| *s != 0) {
-        return Err(PyValueError::new_err("Non-zero strides not supported."));
+    if buf.strides().iter().any(|s| *s != 1) {
+        return Err(PyValueError::new_err(format!(
+            "strides other than 1 not supported, got: {:?} ",
+            buf.strides()
+        )));
     }
 
     Ok(())


### PR DESCRIPTION
Latest clippy adds a new lint: (from https://github.com/developmentseed/obstore/actions/runs/15052401550/job/42310172690?pr=451)

```
error: large size difference between variants
   --> src/store.rs:245:1
    |
245 | / pub enum AnyObjectStore {
246 | |     /// A wrapper around a [`PyObjectStore`].
247 | |     PyObjectStore(PyObjectStore),
    | |     ---------------------------- the second-largest variant contains at least 16 bytes
248 | |     /// A wrapper around a [`PyExternalObjectStore`].
249 | |     PyExternalObjectStore(PyExternalObjectStore),
    | |     -------------------------------------------- the largest variant contains at least 480 bytes
250 | | }
    | |_^ the entire enum is at least 480 bytes
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
    = note: `-D clippy::large-enum-variant` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::large_enum_variant)]`
help: consider boxing the large fields to reduce the total size of the enum
    |
249 -     PyExternalObjectStore(PyExternalObjectStore),
249 +     PyExternalObjectStore(Box<PyExternalObjectStore>),
```

This PR no longer uses an enum for the external object store variants, which should fix the lint.