### PR TITLE
Bump object-store to 0.12.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,7 +1394,8 @@ dependencies = [
 [[package]]
 name = "object_store"
 version = "0.12.1"
-source = "git+https://github.com/apache/arrow-rs-object-store?rev=ed9329f28eba5b1e0f6bbd10c79738ec42a9f568#ed9329f28eba5b1e0f6bbd10c79738ec42a9f568"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d94ac16b433c0ccf75326388c893d2835ab7457ea35ab8ba5d745c053ef5fa16"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ chrono = "0.4.38"
 futures = "0.3.31"
 http = "1.2"
 indexmap = "2"
-object_store = "0.12"
+object_store = "0.12.1"
 pyo3 = { version = "0.24", features = ["macros", "indexmap"] }
 pyo3-async-runtimes = { version = "0.24", features = ["tokio-runtime"] }
 pyo3-file = "0.12"
@@ -37,7 +37,3 @@ url = "2"
 [profile.release]
 lto = true
 codegen-units = 1
-
-[patch.crates-io]
-# 0.12.1 rc
-object_store = { git = 'https://github.com/apache/arrow-rs-object-store', rev = "ed9329f28eba5b1e0f6bbd10c79738ec42a9f568" }


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->

- bumping `object-store` dependency version to `0.12.1`, which was released May 9

This addresses the following error, which appears to be due to 0.12.1rc no longer being available?

```plain
$ uv run maturin develop -m obstore/Cargo.toml
error: failed to load source for dependency `object_store`

Caused by:
  Unable to update https://github.com/apache/arrow-rs-object-store?rev=ed9329f28eba5b1e0f6bbd10c79738ec42a9f568#ed9329f2

Caused by:
  failed to map 'no'; class=Config (7)
💥 maturin failed
  Caused by: Cargo metadata failed. Does your crate compile with `cargo build`?
  Caused by: `cargo metadata` exited with an error: 
```

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- updated `Cargo.toml`

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Run `uv run maturin develop -m obstore/Cargo.toml` to verify the above error does _not_ occur
- Run `cargo test --all` to verify that all tests pass

@kylebarron, in preparation to work on #392, I ran into this problem, but I don't know if the change I made here is the proper way to fix it (i.e., the fix works, but I don't know if this is the "correct" way to fix it).