### PR TITLE
chore: Reduce moto setup/teardown overhead in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev-dependencies = [
     "ruff>=0.11.0",
     "tqdm>=4.67.1",
     "types-boto3[s3,sts]>=1.36.23",
+    "types-requests>=2.31.0.6",
 ]
 constraint-dependencies = [
     # ensure lockfile grabs wheels for pyproj for each Python version

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,9 @@ def s3(moto_server_uri: str):
     yield moto_server_uri
     objects = client.list_objects_v2(Bucket=TEST_BUCKET_NAME)
     for name in objects.get("Contents", []):
-        client.delete_object(Bucket=TEST_BUCKET_NAME, Key=name["Key"])
+        key = name.get("Key")
+        assert key is not None
+        client.delete_object(Bucket=TEST_BUCKET_NAME, Key=key)
     requests.post(f"{moto_server_uri}/moto-api/reset", timeout=30)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ TEST_BUCKET_NAME = "test"
 
 
 # See docs here: https://docs.getmoto.org/en/latest/docs/server_mode.html
-@pytest.fixture
+@pytest.fixture(scope="session")
 def moto_server_uri():
     """Fixture to run a mocked AWS server for testing."""
     # Note: pass `port=0` to get a random free port.
@@ -46,6 +46,9 @@ def s3(moto_server_uri: str):
     client.create_bucket(Bucket=TEST_BUCKET_NAME, ACL="public-read")
     client.put_object(Bucket=TEST_BUCKET_NAME, Key="afile", Body=b"hello world")
     yield moto_server_uri
+    objects = client.list_objects_v2(Bucket=TEST_BUCKET_NAME)
+    for name in objects.get("Contents", []):
+        client.delete_object(Bucket=TEST_BUCKET_NAME, Key=name["Key"])
     requests.post(f"{moto_server_uri}/moto-api/reset", timeout=30)
 
 

--- a/tests/test_fsspec.py
+++ b/tests/test_fsspec.py
@@ -103,10 +103,6 @@ def test_construct_store_cache_diff_bucket_name(s3_store_config: S3Config):
         assert mock_construct.cache_info().hits == 0, "Cache should hits 0 times"
         assert mock_construct.cache_info().misses == 20, "Cache should miss 20 times"
 
-    # test garbage collector
-    del fs
-    assert gc.collect() > 0
-
 
 def test_construct_store_cache_same_bucket_name(s3_store_config: S3Config):
     register("s3")
@@ -135,10 +131,6 @@ def test_construct_store_cache_same_bucket_name(s3_store_config: S3Config):
             "Cache should hits 20-1 times"
         )
         assert mock_construct.cache_info().misses == 1, "Cache should only miss once"
-
-    # test garbage collector
-    del fs
-    assert gc.collect() > 0
 
 
 def test_fsspec_filesystem_cache(s3_store_config: S3Config):

--- a/uv.lock
+++ b/uv.lock
@@ -3361,6 +3361,8 @@ dev = [
     { name = "ruff" },
     { name = "tqdm" },
     { name = "types-boto3", extra = ["s3", "sts"] },
+    { name = "types-requests", version = "2.31.0.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "types-requests", version = "2.32.0.20250515", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 
 [package.metadata]
@@ -3401,6 +3403,7 @@ dev = [
     { name = "ruff", specifier = ">=0.11.0" },
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "types-boto3", extras = ["s3", "sts"], specifier = ">=1.36.23" },
+    { name = "types-requests", specifier = ">=2.31.0.6" },
 ]
 
 [[package]]
@@ -3559,12 +3562,52 @@ wheels = [
 ]
 
 [[package]]
+name = "types-requests"
+version = "2.31.0.6"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "types-urllib3", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/b8/c1e8d39996b4929b918aba10dba5de07a8b3f4c8487bb61bb79882544e69/types-requests-2.31.0.6.tar.gz", hash = "sha256:cd74ce3b53c461f1228a9b783929ac73a666658f223e28ed29753771477b3bd0", size = 15535, upload-time = "2023-09-27T06:19:38.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/a1/6f8dc74d9069e790d604ddae70cb46dcbac668f1bb08136e7b0f2f5cd3bf/types_requests-2.31.0.6-py3-none-any.whl", hash = "sha256:a2db9cb228a81da8348b49ad6db3f5519452dd20a9c1e1a868c83c5fe88fd1a9", size = 14516, upload-time = "2023-09-27T06:19:36.373Z" },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.32.0.20250515"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11'",
+    "python_full_version == '3.10.*'",
+]
+dependencies = [
+    { name = "urllib3", version = "2.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c1/cdc4f9b8cfd9130fbe6276db574f114541f4231fcc6fb29648289e6e3390/types_requests-2.32.0.20250515.tar.gz", hash = "sha256:09c8b63c11318cb2460813871aaa48b671002e59fda67ca909e9883777787581", size = 23012, upload-time = "2025-05-15T03:04:31.817Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/0f/68a997c73a129287785f418c1ebb6004f81e46b53b3caba88c0e03fcd04a/types_requests-2.32.0.20250515-py3-none-any.whl", hash = "sha256:f8eba93b3a892beee32643ff836993f15a785816acca21ea0ffa006f05ef0fb2", size = 20635, upload-time = "2025-05-15T03:04:30.5Z" },
+]
+
+[[package]]
 name = "types-s3transfer"
 version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fb/d5/830e9efe91a26601a2bebde6f299239d2d26e542f5d4b3bc7e8c23c81a3f/types_s3transfer-0.12.0.tar.gz", hash = "sha256:f8f59201481e904362873bf0be3267f259d60ad946ebdfcb847d092a1fa26f98", size = 14096, upload-time = "2025-04-23T00:38:19.131Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/43/6097275152463ac9bacf1e00aab30bc6682bf45f6a031be8bf029c030ba2/types_s3transfer-0.12.0-py3-none-any.whl", hash = "sha256:101bbc5b7f00b71512374df881f480fc6bf63c948b5098ab024bf3370fbfb0e8", size = 19553, upload-time = "2025-04-23T00:38:17.865Z" },
+]
+
+[[package]]
+name = "types-urllib3"
+version = "1.26.25.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/de/b9d7a68ad39092368fb21dd6194b362b98a1daeea5dcfef5e1adb5031c7e/types-urllib3-1.26.25.14.tar.gz", hash = "sha256:229b7f577c951b8c1b92c1bc2b2fdb0b49847bd2af6d1cc2a2e3dd340f3bda8f", size = 11239, upload-time = "2023-07-20T15:19:31.307Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/7b/3fc711b2efea5e85a7a0bbfe269ea944aa767bbba5ec52f9ee45d362ccf3/types_urllib3-1.26.25.14-py3-none-any.whl", hash = "sha256:9683bbb7fb72e32bfe9d2be6e04875fbe1b3eeec3cbb4ea231435aa7fd6b4f0e", size = 15377, upload-time = "2023-07-20T15:19:30.379Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
By passing `scope="session"` we can only start the ThreadedMotoServer once per pytest run.