### PR TITLE
fix: AzureStore creation by HTTPS url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1378,9 +1378,8 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d94ac16b433c0ccf75326388c893d2835ab7457ea35ab8ba5d745c053ef5fa16"
+version = "0.12.2"
+source = "git+https://github.com/apache/arrow-rs-object-store?rev=f422dce1528ee2a089d8061af639c3f2a9cd43af#f422dce1528ee2a089d8061af639c3f2a9cd43af"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ chrono = "0.4.38"
 futures = "0.3.31"
 http = "1.2"
 indexmap = "2"
-object_store = "0.12.1"
+object_store = "0.12.2"
 pyo3 = { version = "0.25", features = ["macros", "indexmap"] }
 pyo3-async-runtimes = { version = "0.25", features = ["tokio-runtime"] }
 pyo3-file = "0.13"
@@ -37,3 +37,6 @@ url = "2"
 [profile.release]
 lto = true
 codegen-units = 1
+
+[patch.crates-io]
+object_store = { git = "https://github.com/apache/arrow-rs-object-store", rev = "f422dce1528ee2a089d8061af639c3f2a9cd43af" }

--- a/tests/store/test_azure.py
+++ b/tests/store/test_azure.py
@@ -32,3 +32,13 @@ def test_eq():
     assert store == store  # noqa: PLR0124
     assert store == store2
     assert store != store3
+
+
+def test_from_url():
+    # https://github.com/developmentseed/obstore/issues/477
+    url = "https://overturemapswestus2.blob.core.windows.net/release"
+    store = AzureStore.from_url(url, skip_signature=True)
+
+    assert store.config.get("container_name") == "release"
+    assert store.config.get("account_name") == "overturemapswestus2"
+    assert store.prefix is None


### PR DESCRIPTION
Closes https://github.com/developmentseed/obstore/issues/477

### Change list

- Closed by https://github.com/apache/arrow-rs-object-store/pull/399
- Bump object_store git tag to f422dc

Closes https://github.com/developmentseed/obstore/pull/478