### PR TITLE
feat: Deprecate custom NotFoundError in favor of built-in FileNotFoundError

### DIFF
--- a/obstore/pyproject.toml
+++ b/obstore/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "obstore"
 requires-python = ">=3.9"
-dependencies = ["typing-extensions; python_version < '3.12'"]
+dependencies = ["typing-extensions; python_version < '3.13'"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Framework :: AsyncIO",

--- a/obstore/python/obstore/exceptions/__init__.pyi
+++ b/obstore/python/obstore/exceptions/__init__.pyi
@@ -2,12 +2,20 @@
 # pylance isn't able to find that. So this is an exceptions module with only
 # `__init__.pyi` to work around pylance's bug.
 
+import sys
+
+if sys.version_info >= (3, 13):
+    from warnings import deprecated
+else:
+    from typing_extensions import deprecated
+
 class BaseError(Exception):
     """The base exception class."""
 
 class GenericError(BaseError):
     """A fallback error type when no variant matches."""
 
+@deprecated("builtins.FileNotFoundError is emitted instead.")
 class NotFoundError(BaseError):
     """Error when the object is not found at given location."""
 


### PR DESCRIPTION
## Available PR templates

<!--
  Github doesn't allow PR template selection the same way that it is possible with issues.
  Preview this and select the appropriate template
-->

- [Default](?expand=1&template=default.md)
- [Version Release](?expand=1&template=version_release.md)
- _Alternatively delete and start empty_
