### PR TITLE
feat: Add `buffer` and `buffer_async` aliases to `GetResult`

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -165,6 +165,7 @@ plugins:
             - https://azuresdkdocs.z19.web.core.windows.net/python/azure-identity/latest/objects.inv
             - https://boto3.amazonaws.com/v1/documentation/api/latest/objects.inv
             - https://botocore.amazonaws.com/v1/documentation/api/latest/objects.inv
+            - https://developmentseed.org/obspec/latest/objects.inv
             - https://docs.aiohttp.org/en/stable/objects.inv
             - https://docs.pola.rs/api/python/stable/objects.inv
             - https://docs.python.org/3/objects.inv

--- a/obstore/python/obstore/_get.pyi
+++ b/obstore/python/obstore/_get.pyi
@@ -187,6 +187,20 @@ class GetResult:
         memory by passing to [`bytes`][].
         """
 
+    def buffer(self) -> Bytes:
+        """Collect the data into a `Bytes` object.
+
+        This is an alias of the [`bytes()`][obstore.GetResult.bytes] method to comply
+        with the [`obspec.Get`][] protocol.
+        """
+
+    async def buffer_async(self) -> Bytes:
+        """Collect the data into a `Bytes` object.
+
+        This is an alias of the [`bytes_async()`][obstore.GetResult.bytes_async] method
+        to comply with the [`obspec.GetAsync`][] protocol.
+        """
+
     @property
     def meta(self) -> ObjectMeta:
         """The ObjectMeta for this object."""

--- a/obstore/src/get.rs
+++ b/obstore/src/get.rs
@@ -177,6 +177,14 @@ impl PyGetResult {
         })
     }
 
+    fn buffer(&self, py: Python) -> PyObjectStoreResult<PyBytes> {
+        self.bytes(py)
+    }
+
+    fn buffer_async<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        self.bytes_async(py)
+    }
+
     #[getter]
     fn attributes(&self) -> PyResult<PyAttributes> {
         Ok(PyAttributes::new(self.attributes.clone()))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dev-dependencies = [
     "arro3-core>=0.4.2",
     "azure-identity>=1.21.0",
     "boto3>=1.38.21",
-    "fastapi>=0.115.12",                  # used in example but added here for pyright CI
+    "fastapi>=0.115.12", # used in example but added here for pyright CI
     "fsspec>=2024.10.0",
     "google-auth>=2.38.0",
     "griffe-inherited-docstrings>=1.0.1",
@@ -52,6 +52,9 @@ constraint-dependencies = [
 
 [tool.uv.workspace]
 members = ["examples/fastapi-example"]
+
+[tool.uv.sources]
+obspec = { git = "https://github.com/developmentseed/obspec" }
 
 [tool.ruff]
 target-version = "py39"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dev-dependencies = [
     "arro3-core>=0.4.2",
     "azure-identity>=1.21.0",
     "boto3>=1.38.21",
-    "fastapi>=0.115.12", # used in example but added here for pyright CI
+    "fastapi>=0.115.12",                  # used in example but added here for pyright CI
     "fsspec>=2024.10.0",
     "google-auth>=2.38.0",
     "griffe-inherited-docstrings>=1.0.1",
@@ -29,7 +29,7 @@ dev-dependencies = [
     "mkdocstrings>=0.27.0",
     "moto[s3,server]>=5.1.1",
     "mypy>=1.15.0",
-    "obspec>=0.1.0b6",
+    "obspec>=0.1.0",
     "pip>=24.2",
     "polars>=1.30.0",
     "pyarrow>=17.0.0",
@@ -52,9 +52,6 @@ constraint-dependencies = [
 
 [tool.uv.workspace]
 members = ["examples/fastapi-example"]
-
-[tool.uv.sources]
-obspec = { git = "https://github.com/developmentseed/obspec" }
 
 [tool.ruff]
 target-version = "py39"

--- a/uv.lock
+++ b/uv.lock
@@ -1981,10 +1981,14 @@ wheels = [
 
 [[package]]
 name = "obspec"
-version = "0.1.0b6"
-source = { git = "https://github.com/developmentseed/obspec#ed31776800c5c9ca30a7ede59ec7f49ec459e877" }
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/94/7a9ad6927cac6ec7680e11772fb692145a05a93bafd80b84f6f0ef12f4e7/obspec-0.1.0.tar.gz", hash = "sha256:b189781a53f82ef8d6abf0c9e77fd4c46ac9f244d5a91eb35ee61c2e2b204a4a", size = 117254, upload-time = "2025-06-25T05:24:00.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/69/96feeac84ce0b871567225c78515f3b557c023e72ed9b4f1833f3662bd6b/obspec-0.1.0-py3-none-any.whl", hash = "sha256:307f0fa2c2998b324ecf0eed6a2a89049a4c40c9b1fa2b5e1af28f0ee72136b3", size = 15231, upload-time = "2025-06-25T05:23:58.735Z" },
 ]
 
 [[package]]
@@ -3395,7 +3399,7 @@ dev = [
     { name = "mkdocstrings-python", specifier = ">=1.13.0" },
     { name = "moto", extras = ["s3", "server"], specifier = ">=5.1.1" },
     { name = "mypy", specifier = ">=1.15.0" },
-    { name = "obspec", git = "https://github.com/developmentseed/obspec" },
+    { name = "obspec", specifier = ">=0.1.0" },
     { name = "pip", specifier = ">=24.2" },
     { name = "polars", specifier = ">=1.30.0" },
     { name = "pyarrow", specifier = ">=17.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1982,13 +1982,9 @@ wheels = [
 [[package]]
 name = "obspec"
 version = "0.1.0b6"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/developmentseed/obspec#ed31776800c5c9ca30a7ede59ec7f49ec459e877" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/3e/d5039e58371e8ebb2884f0ee1072c8b9119950bfe3504daaf812db2d1776/obspec-0.1.0b6.tar.gz", hash = "sha256:df1ffa5517a4b69430f934c6a32511ac566ee0d662dc8325a763540bc0ae652b", size = 111559, upload-time = "2025-05-28T21:08:14.479Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/09/7d3cfeadeb44333051b63cd5acd5315c1848cc49329cf8af880f60e9fd75/obspec-0.1.0b6-py3-none-any.whl", hash = "sha256:dfcfbf61b8512d938716935b24bec2350f9ae489d1fdfde660b7009c76e726b0", size = 14831, upload-time = "2025-05-28T21:08:10.957Z" },
 ]
 
 [[package]]
@@ -3399,7 +3395,7 @@ dev = [
     { name = "mkdocstrings-python", specifier = ">=1.13.0" },
     { name = "moto", extras = ["s3", "server"], specifier = ">=5.1.1" },
     { name = "mypy", specifier = ">=1.15.0" },
-    { name = "obspec", specifier = ">=0.1.0b6" },
+    { name = "obspec", git = "https://github.com/developmentseed/obspec" },
     { name = "pip", specifier = ">=24.2" },
     { name = "polars", specifier = ">=1.30.0" },
     { name = "pyarrow", specifier = ">=17.0.0" },


### PR DESCRIPTION
Also test against latest obspec 0.1 release

This _should_ fail on first go because we haven't implemented https://github.com/developmentseed/obspec/pull/43 yet.

Indeed, and the second commit fixed it.