### PR TITLE
chore: Prepare obstore v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+## [0.7.2] - 2025-07-31
+
+### What's Changed
+
+- feat(fsspec): `FsspecStore.modified()` by @keen85 in https://github.com/developmentseed/obstore/pull/517
+
+### New Contributors
+
+- @keen85 made their first contribution in https://github.com/developmentseed/obstore/pull/517
+
+**Full Changelog**: https://github.com/developmentseed/obstore/compare/py-v0.7.1...py-v0.7.2
+
 ## [0.7.1] - 2025-07-24
 
 ### What's Changed
@@ -21,7 +33,7 @@
 - fix: fix pyright config by @pjonsson in https://github.com/developmentseed/obstore/pull/505
 - ci: reinstate pyright check by @pjonsson in https://github.com/developmentseed/obstore/pull/510
 
-## New Contributors
+### New Contributors
 
 - @pjonsson made their first contribution in https://github.com/developmentseed/obstore/pull/505
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1403,7 +1403,7 @@ dependencies = [
 
 [[package]]
 name = "obstore"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "arrow",
  "bytes",

--- a/obstore/Cargo.toml
+++ b/obstore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "obstore"
-version = "0.7.1"
+version = "0.7.2"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "The simplest, highest-throughput interface to Amazon S3, Google Cloud Storage, Azure Blob Storage, and S3-compliant APIs like Cloudflare R2."


### PR DESCRIPTION
Releases #517 so that the fsspec store can be used with duckdb