### PR TITLE
fix: Fix conversion from python string to Rust Attribute

### DIFF
--- a/obstore/src/attributes.rs
+++ b/obstore/src/attributes.rs
@@ -12,14 +12,14 @@ pub(crate) struct PyAttribute(Attribute);
 
 impl<'py> FromPyObject<'py> for PyAttribute {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
-        let s = ob.extract::<PyBackedStr>()?.to_ascii_lowercase();
-        match s.as_str() {
+        let s = ob.extract::<PyBackedStr>()?;
+        match s.to_ascii_lowercase().as_str() {
             "content-disposition" | "contentdisposition" => Ok(Self(Attribute::ContentDisposition)),
-            "Content-Encoding" | "ContentEncoding" => Ok(Self(Attribute::ContentEncoding)),
-            "Content-Language" | "ContentLanguage" => Ok(Self(Attribute::ContentLanguage)),
-            "Content-Type" | "ContentType" => Ok(Self(Attribute::ContentType)),
-            "Cache-Control" | "CacheControl" => Ok(Self(Attribute::CacheControl)),
-            _ => Ok(Self(Attribute::Metadata(Cow::Owned(s)))),
+            "content-encoding" | "contentencoding" => Ok(Self(Attribute::ContentEncoding)),
+            "content-language" | "contentlanguage" => Ok(Self(Attribute::ContentLanguage)),
+            "content-type" | "contenttype" => Ok(Self(Attribute::ContentType)),
+            "cache-control" | "cachecontrol" => Ok(Self(Attribute::CacheControl)),
+            _ => Ok(Self(Attribute::Metadata(Cow::Owned(s.to_string())))),
         }
     }
 }

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -1,0 +1,19 @@
+from obstore.store import MemoryStore
+
+
+def test_content_type():
+    store = MemoryStore()
+    store.put("test.txt", b"Hello, World!", attributes={"Content-Type": "text/plain"})
+    result = store.get("test.txt")
+    assert result.attributes.get("Content-Type") == "text/plain"
+
+
+def test_custom_attribute():
+    store = MemoryStore()
+    store.put(
+        "test.txt",
+        b"Hello, World!",
+        attributes={"My-Custom-Attribute": "CustomValue"},
+    )
+    result = store.get("test.txt")
+    assert result.attributes.get("My-Custom-Attribute") == "CustomValue"


### PR DESCRIPTION
We had been always taking the lower case of the Python input string, but accidentally matching against case-sensitive strings on the Rust side to convert to the known Rust attributes.

Instead, we fix the case sensitive conversion and don't convert the input text to lower case if it's a custom user attribute.

Closes https://github.com/developmentseed/obstore/issues/519