### PR TITLE
fix: Fix passing down `application_credentials` to GCSStore

### DIFF
--- a/pyo3-object_store/src/gcp/store.rs
+++ b/pyo3-object_store/src/gcp/store.rs
@@ -214,6 +214,11 @@ pub struct PyGoogleConfigKey(GoogleConfigKey);
 impl<'py> FromPyObject<'py> for PyGoogleConfigKey {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let s = ob.extract::<PyBackedStr>()?.to_lowercase();
+        // https://github.com/apache/arrow-rs-object-store/pull/467
+        if s == "application_credentials" {
+            return Ok(Self(GoogleConfigKey::ApplicationCredentials));
+        }
+
         let key = s.parse().map_err(PyObjectStoreError::ObjectStoreError)?;
         Ok(Self(key))
     }

--- a/tests/store/test_gcs.py
+++ b/tests/store/test_gcs.py
@@ -1,6 +1,6 @@
 import pytest
 
-from obstore.exceptions import BaseError
+from obstore.exceptions import BaseError, GenericError
 from obstore.store import GCSStore
 
 
@@ -19,3 +19,11 @@ def test_eq():
     assert store == store  # noqa: PLR0124
     assert store == store2
     assert store != store3
+
+
+def test_application_credentials():
+    # The application_credentials parameter should be correctly passed down
+    # Finalizing the GCSBuilder should try to load and parse those credentials, which
+    # should error here.
+    with pytest.raises(GenericError, match="source: OpenCredentials"):
+        GCSStore("bucket", application_credentials="path/to/creds.json")


### PR DESCRIPTION
Closes https://github.com/developmentseed/obstore/issues/537

See also upstream https://github.com/apache/arrow-rs-object-store/pull/467