### PR TITLE
chore(pyo3-object_store): Bump to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1676,7 +1676,7 @@ dependencies = [
 
 [[package]]
 name = "pyo3-object_store"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/pyo3-object_store/CHANGELOG.md
+++ b/pyo3-object_store/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.6.0] - 2025-09-02
+
+### Breaking changes :wrench:
+
+- Don't percent-encode paths. The implementation of `FromPyObject` for `PyPath` now uses `Path::parse` instead of `Path::from` under the hood. #524
+- Bump to pyo3 0.26.
+
 ## [0.5.0] - 2025-05-19
 
 - Bump to pyo3 0.25.

--- a/pyo3-object_store/Cargo.toml
+++ b/pyo3-object_store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-object_store"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Kyle Barron <kyle@developmentseed.org>"]
 edition = "2021"
 description = "object_store integration for pyo3."

--- a/pyo3-object_store/README.md
+++ b/pyo3-object_store/README.md
@@ -65,5 +65,6 @@ We don't yet have a _great_ solution here for reusing the store builder type hin
 | 0.3.x             | **0.23** :warning: | **0.11** :warning: |
 | 0.4.x             | 0.24               | **0.11** :warning: |
 | 0.5.x             | 0.25               | 0.12               |
+| 0.6.x             | 0.26               | 0.12               |
 
 Note that 0.3.x and 0.4.x are compatibility releases to use `pyo3-object_store` with older versions of `pyo3` and `object_store`.


### PR DESCRIPTION
## Available PR templates

<!--
  Github doesn't allow PR template selection the same way that it is possible with issues.
  Preview this and select the appropriate template
-->

- [Default](?expand=1&template=default.md)
- [Version Release](?expand=1&template=version_release.md)
- _Alternatively delete and start empty_
