### PR TITLE
chore: Prepare obstore 0.8.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+## [0.8.2] - 2025-09-16
+
+### What's Changed
+
+- Added sdist and wheels for Python 3.14 (except Windows) @kylebarron in https://github.com/developmentseed/obstore/pull/561 and https://github.com/developmentseed/obstore/pull/563
+- test: Set up minio-based testing, replace moto by @kylebarron in https://github.com/developmentseed/obstore/pull/553
+- chore: Bump ruff to 0.13 by @kylebarron in https://github.com/developmentseed/obstore/pull/562
+- docs: Use dictionary syntax for list properties by @mdsumner in https://github.com/developmentseed/obstore/pull/558
+
+### New Contributors
+
+- @mdsumner made their first contribution in https://github.com/developmentseed/obstore/pull/558
+
+**Full Changelog**: https://github.com/developmentseed/obstore/compare/py-v0.8.1...py-v0.8.2
+
 ## [0.8.1] - 2025-08-22
 
 ## What's Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,7 +1414,7 @@ dependencies = [
 
 [[package]]
 name = "obstore"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "arrow",
  "bytes",

--- a/obstore/Cargo.toml
+++ b/obstore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "obstore"
-version = "0.8.1"
+version = "0.8.2"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "The simplest, highest-throughput interface to Amazon S3, Google Cloud Storage, Azure Blob Storage, and S3-compliant APIs like Cloudflare R2."


### PR DESCRIPTION
## Available PR templates

<!--
  Github doesn't allow PR template selection the same way that it is possible with issues.
  Preview this and select the appropriate template
-->

- [Default](?expand=1&template=default.md)
- [Version Release](?expand=1&template=version_release.md)
- _Alternatively delete and start empty_
