### PR TITLE
chore: remove TODO for deprecated warning

### DIFF
--- a/pyo3-object_store/src/prefix.rs
+++ b/pyo3-object_store/src/prefix.rs
@@ -10,11 +10,9 @@ use std::ops::Range;
 use std::sync::OnceLock;
 
 use object_store::{path::Path, CopyOptions};
-// Remove when updating to object_store 0.13
-#[allow(deprecated)]
 use object_store::{
-    GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore, PutMultipartOpts,
-    PutOptions, PutPayload, PutResult, Result,
+    GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+    PutMultipartOptions, PutOptions, PutPayload, PutResult, Result,
 };
 
 static DEFAULT_PATH: OnceLock<Path> = OnceLock::new();
@@ -127,7 +125,7 @@ impl<T: ObjectStore> ObjectStore for MaybePrefixedStore<T> {
     async fn put_multipart_opts(
         &self,
         location: &Path,
-        opts: PutMultipartOpts,
+        opts: PutMultipartOptions,
     ) -> Result<Box<dyn MultipartUpload>> {
         let full_path = self.full_path(location);
         self.inner.put_multipart_opts(&full_path, opts).await


### PR DESCRIPTION
See https://github.com/developmentseed/obstore/pull/600#discussion_r2684495697