### PR TITLE
Add import statement for obstore in examples

### DIFF
--- a/obstore/python/obstore/auth/earthdata.py
+++ b/obstore/python/obstore/auth/earthdata.py
@@ -63,6 +63,7 @@ class NasaEarthdataCredentialProvider:
 
     Examples:
         ```py
+        import obstore
         from obstore.store import S3Store
         from obstore.auth.earthdata import NasaEarthdataCredentialProvider
 


### PR DESCRIPTION
Just ran into an issue with the example here. I think we might also be able to replace
```
obstore.get(store, filename) 
# with
store.get(filename)
```
?