### PR TITLE
ci: Enable Rust trusted publishing for pyo3 bytes and object_store

### DIFF
--- a/.github/workflows/rust-release-pyo3-bytes.yml
+++ b/.github/workflows/rust-release-pyo3-bytes.yml
@@ -1,0 +1,20 @@
+name: Publish pyo3-bytes to crates.io
+on:
+  push:
+    # Triggers when pushing tags starting with 'pyo3-bytes-v'
+    tags: ["pyo3-bytes-v*"]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # Optional: for enhanced security
+    environment: rust-release-pyo3-bytes
+    permissions:
+      id-token: write # Required for OIDC token exchange
+    steps:
+      - uses: actions/checkout@v5
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+      - run: cargo publish -p pyo3-bytes
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/rust-release-pyo3-object_store.yml
+++ b/.github/workflows/rust-release-pyo3-object_store.yml
@@ -1,0 +1,20 @@
+name: Publish pyo3-object_store to crates.io
+on:
+  push:
+    # Triggers when pushing tags starting with 'pyo3-object_store-v'
+    tags: ["pyo3-object_store-v*"]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # Optional: for enhanced security
+    environment: rust-release-pyo3-object_store
+    permissions:
+      id-token: write # Required for OIDC token exchange
+    steps:
+      - uses: actions/checkout@v5
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+      - run: cargo publish -p pyo3-object_store
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
Publish new versions of `pyo3-bytes` and `pyo3-object_store` on demand and automatically