### PR TITLE
docs: Add DEVELOP.md for pyo3-* to describe publishing

### DIFF
--- a/pyo3-bytes/DEVELOP.md
+++ b/pyo3-bytes/DEVELOP.md
@@ -1,0 +1,5 @@
+## Publishing to crates.io
+
+To publish to crates.io, we have Github Actions workflows set up to publish when pushing tags with specific formats.
+
+- To publish `pyo3-bytes`, push a tag like `pyo3-bytes-vX.Y.Z` where `X.Y.Z` is the new version.

--- a/pyo3-object_store/DEVELOP.md
+++ b/pyo3-object_store/DEVELOP.md
@@ -1,0 +1,5 @@
+## Publishing to crates.io
+
+To publish to crates.io, we have Github Actions workflows set up to publish when pushing tags with specific formats.
+
+- To publish `pyo3-object_store`, push a tag like `pyo3-object_store-vX.Y.Z` where `X.Y.Z` is the new version.


### PR DESCRIPTION
Small docs update to describe how to publish `pyo3-bytes` and `pyo3-object_store` now that we have trusted publishing.