### PR TITLE
fix(fsspec): _info() should honor self.dircache

### DIFF
--- a/obstore/python/obstore/fsspec.py
+++ b/obstore/python/obstore/fsspec.py
@@ -487,6 +487,16 @@ class FsspecStore(fsspec.asyn.AsyncFileSystem):
         await self._local_store._pipe_file(lpath, resp)  # noqa: SLF001
 
     async def _info(self, path: str, **_kwargs: Any) -> dict[str, Any]:
+        # Consult `self.dircache` before issuing a HEAD request. An empty
+        # filter means the cache has evidence `path` is a directory but no
+        # entry under that exact name, so we return a synthetic directory.
+        cached = self._ls_from_cache(path)
+        if cached is not None:
+            match = next((entry for entry in cached if entry["name"] == path), None)
+            if match is not None:
+                return match
+            return {"name": path, "size": 0, "type": "directory"}
+
         bucket, path_no_bucket = self._split_path(path)
         store = self._construct_store(bucket)
 

--- a/tests/test_fsspec.py
+++ b/tests/test_fsspec.py
@@ -71,6 +71,90 @@ def test_register():
     assert issubclass(fsspec.get_filesystem_class("abfs"), FsspecStore)
 
 
+@pytest.mark.asyncio
+async def test_info_returns_cached_entry_without_constructing_store():
+    register("file")
+    fs: FsspecStore = fsspec.filesystem("file", asynchronous=True)
+
+    cached_entry = {
+        "name": "bucket/file.parquet",
+        "size": 12345,
+        "type": "file",
+        "e_tag": None,
+        "last_modified": None,
+        "version": None,
+    }
+    fs.dircache["bucket"] = [cached_entry]
+
+    with patch.object(fs, "_construct_store") as mock_construct:
+        result = await fs._info("bucket/file.parquet")
+
+    assert result == cached_entry
+    assert mock_construct.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_info_falls_through_to_head_on_dircache_miss():
+    register("file")
+    fs: FsspecStore = fsspec.filesystem("file", asynchronous=True)
+    assert fs.dircache == {}
+
+    with patch.object(fs, "_construct_store") as mock_construct:
+        mock_construct.side_effect = RuntimeError("HEAD path entered")
+        with pytest.raises(RuntimeError, match="HEAD path entered"):
+            await fs._info("bucket/some/file.parquet")
+
+    assert mock_construct.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_info_raises_filenotfound_when_parent_cached_and_child_absent():
+    register("file")
+    fs: FsspecStore = fsspec.filesystem("file", asynchronous=True)
+    fs.dircache["bucket"] = [
+        {"name": "bucket/other.parquet", "type": "file", "size": 1},
+    ]
+
+    with (
+        patch.object(fs, "_construct_store") as mock_construct,
+        pytest.raises(FileNotFoundError),
+    ):
+        await fs._info("bucket/missing.parquet")
+
+    assert mock_construct.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_info_synthesizes_directory_when_path_is_cached_dir_key():
+    register("file")
+    fs: FsspecStore = fsspec.filesystem("file", asynchronous=True)
+    fs.dircache["bucket/sub"] = [
+        {"name": "bucket/sub/child1", "type": "file", "size": 1},
+        {"name": "bucket/sub/child2", "type": "file", "size": 2},
+    ]
+
+    with patch.object(fs, "_construct_store") as mock_construct:
+        result = await fs._info("bucket/sub")
+
+    assert result == {"name": "bucket/sub", "size": 0, "type": "directory"}
+    assert mock_construct.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_info_synthesizes_directory_for_trailing_slash_query():
+    register("file")
+    fs: FsspecStore = fsspec.filesystem("file", asynchronous=True)
+    fs.dircache["bucket"] = [
+        {"name": "bucket/sub", "type": "directory", "size": 0},
+    ]
+
+    with patch.object(fs, "_construct_store") as mock_construct:
+        result = await fs._info("bucket/sub/")
+
+    assert result == {"name": "bucket/sub/", "size": 0, "type": "directory"}
+    assert mock_construct.call_count == 0
+
+
 def test_construct_store_cache_diff_bucket_name(
     minio_bucket: tuple[S3Config, ClientConfig],
 ):


### PR DESCRIPTION
# Summary
This PR eliminates unnecessary network calls in `FsspecStore._info()` by ensuring it consults the directory cache before falling back to a network request, bringing it into alignment with standard fsspec implementations.

Currently, `FsspecStore._info()` issues an unconditional `head_async()` and ignores `self.dircache`, even though [`AbstractFileSystem._ls_from_cache`](https://github.com/fsspec/filesystem_spec/blob/0bb819cf923b8680ac473f6a2faf492ab4d3602f/fsspec/spec.py#L364) is documented as the standard way for callers to surface pre-known file metadata. 

For comparison, both [s3fs](https://github.com/fsspec/s3fs/blob/731e1250bcd4f682e1ccce03b01641910e7646fc/s3fs/core.py#L1698-L1730) and [gcsfs](https://github.com/fsspec/gcsfs/blob/64936ae72aa99024282189333b476f0875bbb0ca/gcsfs/core.py#L1048-L1080) consult `_ls_from_cache()` first and only fall back to a network call on miss. `obstore.fsspec.FsspecStore` is the outlier here: pre-populating `fs.dircache` (or having it populated by a prior `_ls`) is ignored.

# Notes
When the parent directory is cached, and the requested child is not in the listing, `_info()` now raises `FileNotFoundError` immediately instead of falling through to a `_ls()`. This matches `s3fs._info` and the documented contract of `_ls_from_cache`: a cached parent listing is authoritative, so a missing child definitively does not exist.