### PR TITLE
feat!: open_reader accepts optional size to skip HEAD request

### DIFF
--- a/obstore/python/obstore/_buffered.pyi
+++ b/obstore/python/obstore/_buffered.pyi
@@ -26,6 +26,7 @@ def open_reader(
     path: str,
     *,
     buffer_size: int = 1024 * 1024,
+    size: int | None = None,
 ) -> ReadableFile:
     """Open a readable file object from the specified location.
 
@@ -35,6 +36,11 @@ def open_reader(
 
     Keyword Args:
         buffer_size: The minimum number of bytes to read in a single request. Up to `buffer_size` bytes will be buffered in memory.
+        size: Optional byte size of the object. When provided, skips the HEAD request used to fetch the file size. Useful for callers that already know the size from external metadata.
+
+            The caller is responsible for accuracy: a value larger than the actual file surfaces as a read-time range error, a value smaller causes silent truncation.
+
+            When `size` is provided, the resulting reader's `meta` attribute omits `last_modified` (since it was not fetched). Callers that need that field should call `open_reader` without `size`. Defaults to `None`.
 
     Returns:
         ReadableFile
@@ -46,6 +52,7 @@ async def open_reader_async(
     path: str,
     *,
     buffer_size: int = 1024 * 1024,
+    size: int | None = None,
 ) -> AsyncReadableFile:
     """Call `open_reader` asynchronously, returning a readable file object with asynchronous operations.
 

--- a/obstore/python/obstore/_buffered.pyi
+++ b/obstore/python/obstore/_buffered.pyi
@@ -3,7 +3,6 @@ from contextlib import AbstractAsyncContextManager, AbstractContextManager
 
 from ._attributes import Attributes
 from ._bytes import Bytes
-from ._list import ObjectMeta
 from ._store import ObjectStore
 
 if sys.version_info >= (3, 11):
@@ -15,11 +14,6 @@ if sys.version_info >= (3, 12):
     from collections.abc import Buffer
 else:
     from typing_extensions import Buffer
-
-if sys.version_info >= (3, 13):
-    from warnings import deprecated
-else:
-    from typing_extensions import deprecated
 
 def open_reader(
     store: ObjectStore,
@@ -38,9 +32,7 @@ def open_reader(
         buffer_size: The minimum number of bytes to read in a single request. Up to `buffer_size` bytes will be buffered in memory.
         size: Optional byte size of the object. When provided, skips the HEAD request used to fetch the file size. Useful for callers that already know the size from external metadata.
 
-            The caller is responsible for accuracy: a value larger than the actual file surfaces as a read-time range error, a value smaller causes silent truncation.
-
-            When `size` is provided, the resulting reader's `meta` attribute omits `last_modified` (since it was not fetched). Callers that need that field should call `open_reader` without `size`. Defaults to `None`.
+            The caller is responsible for accuracy: a value larger than the actual file surfaces as a read-time range error, a value smaller causes silent truncation. Defaults to `None`.
 
     Returns:
         ReadableFile
@@ -97,22 +89,6 @@ class ReadableFile:
         """Close the current file.
 
         This is currently a no-op.
-        """
-
-    @property
-    @deprecated(
-        "`ReadableFile.meta` is deprecated and will be removed in a future release. "
-        "Use the `head` or `head_async` methods directly if you need object metadata.",
-    )
-    def meta(self) -> ObjectMeta:
-        """Access the metadata of the underlying file.
-
-        !!! warning "Deprecated"
-
-            This attribute is deprecated and will be removed in a future
-            release. Use the [`head`][obstore.head] or
-            [`head_async`][obstore.head_async] methods directly if you need
-            object metadata.
         """
 
     def read(self, size: int | None = None, /) -> Bytes:
@@ -191,22 +167,6 @@ class AsyncReadableFile:
         """Close the current file.
 
         This is currently a no-op.
-        """
-
-    @property
-    @deprecated(
-        "`AsyncReadableFile.meta` is deprecated and will be removed in a future release. "
-        "Use the `head` or `head_async` methods directly if you need object metadata.",
-    )
-    def meta(self) -> ObjectMeta:
-        """Access the metadata of the underlying file.
-
-        !!! warning "Deprecated"
-
-            This attribute is deprecated and will be removed in a future
-            release. Use the [`head`][obstore.head] or
-            [`head_async`][obstore.head_async] methods directly if you need
-            object metadata.
         """
 
     async def read(self, size: int | None = None, /) -> Bytes:

--- a/obstore/python/obstore/fsspec.py
+++ b/obstore/python/obstore/fsspec.py
@@ -681,7 +681,12 @@ class BufferedFile(fsspec.spec.AbstractBufferedFile):
 
         if self.mode == "rb":
             buffer_size = 1024 * 1024 if buffer_size is None else buffer_size
-            self._reader = open_reader(store, path, buffer_size=buffer_size)
+            self._reader = open_reader(
+                store,
+                path,
+                buffer_size=buffer_size,
+                size=self.size,
+            )
         elif self.mode == "wb":
             buffer_size = 10 * 1024 * 1024 if buffer_size is None else buffer_size
             self._writer = open_writer(

--- a/obstore/src/buffered.rs
+++ b/obstore/src/buffered.rs
@@ -2,11 +2,13 @@ use std::io::SeekFrom;
 use std::sync::Arc;
 
 use bytes::Bytes;
+use chrono::{DateTime, Utc};
+use indexmap::IndexMap;
 use object_store::buffered::{BufReader, BufWriter};
 use object_store::{ObjectMeta, ObjectStore, ObjectStoreExt};
-use pyo3::exceptions::{PyDeprecationWarning, PyIOError, PyStopAsyncIteration, PyStopIteration};
+use pyo3::exceptions::{PyIOError, PyStopAsyncIteration, PyStopIteration};
 use pyo3::prelude::*;
-use pyo3::types::PyString;
+use pyo3::types::{PyDict, PyString};
 use pyo3::{intern, IntoPyObjectExt};
 use pyo3_async_runtimes::tokio::{future_into_py, get_runtime};
 use pyo3_bytes::PyBytes;
@@ -15,35 +17,39 @@ use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncSeekExt, AsyncWriteExt, Line
 use tokio::sync::Mutex;
 
 use crate::attributes::PyAttributes;
-use crate::list::PyObjectMeta;
 use crate::tags::PyTagSet;
 
 #[pyfunction]
-#[pyo3(signature = (store, path, *, buffer_size=1024 * 1024))]
+#[pyo3(signature = (store, path, *, buffer_size=1024 * 1024, size=None))]
 pub(crate) fn open_reader(
     py: Python,
     store: PyObjectStore,
     path: PyPath,
     buffer_size: usize,
+    size: Option<u64>,
 ) -> PyObjectStoreResult<PyReadableFile> {
     let store = store.into_inner();
     let runtime = get_runtime();
-    let (reader, meta) = py.detach(|| runtime.block_on(create_reader(store, path, buffer_size)))?;
-    Ok(PyReadableFile::new(reader, meta, false))
+    let was_hinted = size.is_some();
+    let (reader, meta) =
+        py.detach(|| runtime.block_on(create_reader(store, path, buffer_size, size)))?;
+    Ok(PyReadableFile::new(reader, meta, was_hinted, false))
 }
 
 #[pyfunction]
-#[pyo3(signature = (store, path, *, buffer_size=1024 * 1024))]
+#[pyo3(signature = (store, path, *, buffer_size=1024 * 1024, size=None))]
 pub(crate) fn open_reader_async(
     py: Python,
     store: PyObjectStore,
     path: PyPath,
     buffer_size: usize,
+    size: Option<u64>,
 ) -> PyResult<Bound<PyAny>> {
     let store = store.into_inner();
+    let was_hinted = size.is_some();
     future_into_py(py, async move {
-        let (reader, meta) = create_reader(store, path, buffer_size).await?;
-        Ok(PyReadableFile::new(reader, meta, true))
+        let (reader, meta) = create_reader(store, path, buffer_size, size).await?;
+        Ok(PyReadableFile::new(reader, meta, was_hinted, true))
     })
 }
 
@@ -51,11 +57,22 @@ async fn create_reader(
     store: Arc<dyn ObjectStore>,
     path: PyPath,
     capacity: usize,
+    size: Option<u64>,
 ) -> PyObjectStoreResult<(BufReader, ObjectMeta)> {
-    let meta = store
-        .head(path.as_ref())
-        .await
-        .map_err(PyObjectStoreError::ObjectStoreError)?;
+    let meta = match size {
+        Some(size) => ObjectMeta {
+            location: path.as_ref().clone(),
+            last_modified: DateTime::<Utc>::from_timestamp(0, 0)
+                .expect("unix epoch is a valid DateTime"),
+            size,
+            e_tag: None,
+            version: None,
+        },
+        None => store
+            .head(path.as_ref())
+            .await
+            .map_err(PyObjectStoreError::ObjectStoreError)?,
+    };
     Ok((BufReader::with_capacity(store, &meta, capacity), meta))
 }
 
@@ -63,14 +80,16 @@ async fn create_reader(
 pub(crate) struct PyReadableFile {
     reader: Arc<Mutex<BufReader>>,
     meta: ObjectMeta,
+    was_hinted: bool,
     r#async: bool,
 }
 
 impl PyReadableFile {
-    fn new(reader: BufReader, meta: ObjectMeta, r#async: bool) -> Self {
+    fn new(reader: BufReader, meta: ObjectMeta, was_hinted: bool, r#async: bool) -> Self {
         Self {
             reader: Arc::new(Mutex::new(reader)),
             meta,
+            was_hinted,
             r#async,
         }
     }
@@ -92,14 +111,19 @@ impl PyReadableFile {
     fn close(&self) {}
 
     #[getter]
-    fn meta(&self, py: Python) -> PyResult<PyObjectMeta> {
-        let warnings_mod = py.import(intern!(py, "warnings"))?;
-        let warning = PyDeprecationWarning::new_err(
-            "The `meta` attribute is deprecated and will be removed in a future release. \
-             Use the `head` or `head_async` methods directly if you need object metadata.",
-        );
-        warnings_mod.call_method1(intern!(py, "warn"), (warning,))?;
-        Ok(self.meta.clone().into())
+    fn meta<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let mut dict = IndexMap::with_capacity(5);
+        dict.insert("path", self.meta.location.as_ref().into_bound_py_any(py)?);
+        if !self.was_hinted {
+            dict.insert(
+                "last_modified",
+                self.meta.last_modified.into_bound_py_any(py)?,
+            );
+        }
+        dict.insert("size", self.meta.size.into_bound_py_any(py)?);
+        dict.insert("e_tag", self.meta.e_tag.clone().into_bound_py_any(py)?);
+        dict.insert("version", self.meta.version.clone().into_bound_py_any(py)?);
+        dict.into_pyobject(py)
     }
 
     #[pyo3(signature = (size = None, /))]

--- a/obstore/src/buffered.rs
+++ b/obstore/src/buffered.rs
@@ -2,13 +2,11 @@ use std::io::SeekFrom;
 use std::sync::Arc;
 
 use bytes::Bytes;
-use chrono::{DateTime, Utc};
-use indexmap::IndexMap;
 use object_store::buffered::{BufReader, BufWriter};
 use object_store::{ObjectMeta, ObjectStore, ObjectStoreExt};
 use pyo3::exceptions::{PyIOError, PyStopAsyncIteration, PyStopIteration};
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyString};
+use pyo3::types::PyString;
 use pyo3::{intern, IntoPyObjectExt};
 use pyo3_async_runtimes::tokio::{future_into_py, get_runtime};
 use pyo3_bytes::PyBytes;
@@ -30,10 +28,9 @@ pub(crate) fn open_reader(
 ) -> PyObjectStoreResult<PyReadableFile> {
     let store = store.into_inner();
     let runtime = get_runtime();
-    let was_hinted = size.is_some();
-    let (reader, meta) =
+    let (reader, resolved_size) =
         py.detach(|| runtime.block_on(create_reader(store, path, buffer_size, size)))?;
-    Ok(PyReadableFile::new(reader, meta, was_hinted, false))
+    Ok(PyReadableFile::new(reader, resolved_size, false))
 }
 
 #[pyfunction]
@@ -46,10 +43,9 @@ pub(crate) fn open_reader_async(
     size: Option<u64>,
 ) -> PyResult<Bound<PyAny>> {
     let store = store.into_inner();
-    let was_hinted = size.is_some();
     future_into_py(py, async move {
-        let (reader, meta) = create_reader(store, path, buffer_size, size).await?;
-        Ok(PyReadableFile::new(reader, meta, was_hinted, true))
+        let (reader, resolved_size) = create_reader(store, path, buffer_size, size).await?;
+        Ok(PyReadableFile::new(reader, resolved_size, true))
     })
 }
 
@@ -58,12 +54,11 @@ async fn create_reader(
     path: PyPath,
     capacity: usize,
     size: Option<u64>,
-) -> PyObjectStoreResult<(BufReader, ObjectMeta)> {
+) -> PyObjectStoreResult<(BufReader, u64)> {
     let meta = match size {
         Some(size) => ObjectMeta {
             location: path.as_ref().clone(),
-            last_modified: DateTime::<Utc>::from_timestamp(0, 0)
-                .expect("unix epoch is a valid DateTime"),
+            last_modified: Default::default(),
             size,
             e_tag: None,
             version: None,
@@ -73,23 +68,22 @@ async fn create_reader(
             .await
             .map_err(PyObjectStoreError::ObjectStoreError)?,
     };
-    Ok((BufReader::with_capacity(store, &meta, capacity), meta))
+    let size = meta.size;
+    Ok((BufReader::with_capacity(store, &meta, capacity), size))
 }
 
 #[pyclass(name = "ReadableFile", frozen)]
 pub(crate) struct PyReadableFile {
     reader: Arc<Mutex<BufReader>>,
-    meta: ObjectMeta,
-    was_hinted: bool,
+    size: u64,
     r#async: bool,
 }
 
 impl PyReadableFile {
-    fn new(reader: BufReader, meta: ObjectMeta, was_hinted: bool, r#async: bool) -> Self {
+    fn new(reader: BufReader, size: u64, r#async: bool) -> Self {
         Self {
             reader: Arc::new(Mutex::new(reader)),
-            meta,
-            was_hinted,
+            size,
             r#async,
         }
     }
@@ -109,22 +103,6 @@ impl PyReadableFile {
     // Maybe this should dispose of the internal reader? In that case we want to store an
     // `Option<Arc<Mutex<BufReader>>>`.
     fn close(&self) {}
-
-    #[getter]
-    fn meta<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
-        let mut dict = IndexMap::with_capacity(5);
-        dict.insert("path", self.meta.location.as_ref().into_bound_py_any(py)?);
-        if !self.was_hinted {
-            dict.insert(
-                "last_modified",
-                self.meta.last_modified.into_bound_py_any(py)?,
-            );
-        }
-        dict.insert("size", self.meta.size.into_bound_py_any(py)?);
-        dict.insert("e_tag", self.meta.e_tag.clone().into_bound_py_any(py)?);
-        dict.insert("version", self.meta.version.clone().into_bound_py_any(py)?);
-        dict.into_pyobject(py)
-    }
 
     #[pyo3(signature = (size = None, /))]
     fn read<'py>(&'py self, py: Python<'py>, size: Option<usize>) -> PyResult<Bound<'py, PyAny>> {
@@ -203,7 +181,7 @@ impl PyReadableFile {
 
     #[getter]
     fn size(&self) -> u64 {
-        self.meta.size
+        self.size
     }
 
     fn tell<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {

--- a/tests/test_buffered.py
+++ b/tests/test_buffered.py
@@ -171,18 +171,11 @@ def test_open_reader_size_hint_zero_byte_file():
     assert memoryview(b"") == memoryview(file.read())
 
 
-def test_open_reader_meta_last_modified_depends_on_size_hint():
+def test_open_reader_no_longer_exposes_meta():
     store = MemoryStore()
     data = b"x" * 1000
     path = "sized.bin"
     obs.put(store, path, data)
 
-    hinted = obs.open_reader(store, path, size=len(data))
-    unhinted = obs.open_reader(store, path)
-
-    assert "last_modified" not in hinted.meta
-    assert "last_modified" in unhinted.meta
-    assert hinted.meta["size"] == len(data)
-    assert unhinted.meta["size"] == len(data)
-    assert hinted.meta["e_tag"] is None
-    assert hinted.meta["path"] == path
+    file = obs.open_reader(store, path)
+    assert not hasattr(file, "meta")

--- a/tests/test_buffered.py
+++ b/tests/test_buffered.py
@@ -114,28 +114,75 @@ async def test_read_past_eof_async():
     assert memoryview(expected) == memoryview(buffer)
 
 
-def test_readable_file_meta_emits_deprecation_warning():
+def test_open_reader_size_hint_sync():
     store = MemoryStore()
+    data = b"x" * 1000
     path = "sized.bin"
-    obs.put(store, path, b"x" * 100)
+    obs.put(store, path, data)
 
-    file = obs.open_reader(store, path)
-    with pytest.warns(DeprecationWarning, match="`meta` attribute is deprecated"):
-        meta = file.meta
-
-    assert meta["size"] == 100
-    assert meta["path"] == path
+    file = obs.open_reader(store, path, size=len(data))
+    assert file.size == len(data)
+    assert memoryview(data) == memoryview(file.read())
 
 
 @pytest.mark.asyncio
-async def test_async_readable_file_meta_emits_deprecation_warning():
+async def test_open_reader_size_hint_async():
     store = MemoryStore()
+    data = b"x" * 1000
     path = "sized.bin"
-    await obs.put_async(store, path, b"x" * 100)
+    await obs.put_async(store, path, data)
 
-    file = await obs.open_reader_async(store, path)
-    with pytest.warns(DeprecationWarning, match="`meta` attribute is deprecated"):
-        meta = file.meta
+    file = await obs.open_reader_async(store, path, size=len(data))
+    assert file.size == len(data)
+    assert memoryview(data) == memoryview(await file.read())
 
-    assert meta["size"] == 100
-    assert meta["path"] == path
+
+def test_open_reader_size_hint_larger_than_actual_errors_on_read():
+    store = MemoryStore()
+    data = b"x" * 1000
+    path = "sized.bin"
+    obs.put(store, path, data)
+
+    file = obs.open_reader(store, path, size=5000)
+    assert file.size == 5000
+    with pytest.raises(OSError, match="range"):
+        file.read()
+
+
+def test_open_reader_size_hint_smaller_than_actual_truncates():
+    store = MemoryStore()
+    data = b"x" * 1000
+    path = "sized.bin"
+    obs.put(store, path, data)
+
+    file = obs.open_reader(store, path, size=500)
+    assert file.size == 500
+    buffer = file.read()
+    assert memoryview(data[:500]) == memoryview(buffer)
+
+
+def test_open_reader_size_hint_zero_byte_file():
+    store = MemoryStore()
+    path = "empty.bin"
+    obs.put(store, path, b"")
+
+    file = obs.open_reader(store, path, size=0)
+    assert file.size == 0
+    assert memoryview(b"") == memoryview(file.read())
+
+
+def test_open_reader_meta_last_modified_depends_on_size_hint():
+    store = MemoryStore()
+    data = b"x" * 1000
+    path = "sized.bin"
+    obs.put(store, path, data)
+
+    hinted = obs.open_reader(store, path, size=len(data))
+    unhinted = obs.open_reader(store, path)
+
+    assert "last_modified" not in hinted.meta
+    assert "last_modified" in unhinted.meta
+    assert hinted.meta["size"] == len(data)
+    assert unhinted.meta["size"] == len(data)
+    assert hinted.meta["e_tag"] is None
+    assert hinted.meta["path"] == path

--- a/tests/test_fsspec.py
+++ b/tests/test_fsspec.py
@@ -167,7 +167,6 @@ def test_buffered_file_forwards_size_to_open_reader():
 
         assert file.size == 500
         assert file._reader.size == 500
-        assert "last_modified" not in file._reader.meta
 
         data = file.read()
         assert len(data) == 500

--- a/tests/test_fsspec.py
+++ b/tests/test_fsspec.py
@@ -155,6 +155,24 @@ async def test_info_synthesizes_directory_for_trailing_slash_query():
     assert mock_construct.call_count == 0
 
 
+def test_buffered_file_forwards_size_to_open_reader():
+    register("file")
+    fs: FsspecStore = fsspec.filesystem("file", asynchronous=False)
+
+    with TemporaryDirectory() as tmp:
+        path = Path(tmp) / "sized.bin"
+        path.write_bytes(b"x" * 1000)
+
+        file = fs._open(str(path), mode="rb", size=500)
+
+        assert file.size == 500
+        assert file._reader.size == 500
+        assert "last_modified" not in file._reader.meta
+
+        data = file.read()
+        assert len(data) == 500
+
+
 def test_construct_store_cache_diff_bucket_name(
     minio_bucket: tuple[S3Config, ClientConfig],
 ):


### PR DESCRIPTION
# Summary
Add an optional `size` parameter to `obstore.open_reader` / `open_reader_async` that lets callers skip the `HEAD` request used to fetch the file size when the size is already known from external metadata.

[`create_reader`](https://github.com/developmentseed/obstore/blob/996978aeda7f298b99df441338fcfee685d2bcce/obstore/src/buffered.rs#L50-L60) currently HEADs the object solely to populate an `ObjectMeta`, but [`BufReader::with_capacity`](https://github.com/apache/arrow-rs-object-store/blob/62592027cb7d33ed843bc14fb77d7fc32f13ace5/src/buffered.rs#L94-L101) consumes only `meta.location` and `meta.size` from it. There is a network round-trip per file to fetch a single `u64`.

The same pattern already exists one layer up in the arrow-rs workspace: [`parquet::arrow::async_reader::ParquetObjectReader::with_file_size(u64)`](https://github.com/apache/arrow-rs/blob/68851ef953fd771cc310203c446e54145d4407e1/parquet/src/arrow/async_reader/store.rs#L88-L102) accepts an optional size hint as `Option<u64>`. Python-side similar examples exist in [`fsspec.AbstractBufferedFile(size=None)`](https://github.com/fsspec/filesystem_spec/blob/0bb819cf923b8680ac473f6a2faf492ab4d3602f/fsspec/spec.py#L1864) and [`pyarrow.dataset.FileFormat.make_fragment(file_size=None)`](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.FileFormat.html#pyarrow.dataset.FileFormat.make_fragment).

When `size` is provided, `create_reader` constructs the `ObjectMeta` directly with the hint and skips the `HEAD` entirely. When `size` is `None`, behavior is the same as before.

# Notes
The caller is responsible for the `size` value being accurate.
Failure modes:
- A hint larger than the actual file surfaces as an `OSError` at read time, when a range request past EOF is issued (`Invalid range`).
- A hint smaller than the actual file causes silent truncation: the reader treats the hint as authoritative EOF.
