### PR TITLE
feat(buffered): deprecate ReadableFile.meta and AsyncReadableFile.meta

### DIFF
--- a/obstore/python/obstore/_buffered.pyi
+++ b/obstore/python/obstore/_buffered.pyi
@@ -16,6 +16,11 @@ if sys.version_info >= (3, 12):
 else:
     from typing_extensions import Buffer
 
+if sys.version_info >= (3, 13):
+    from warnings import deprecated
+else:
+    from typing_extensions import deprecated
+
 def open_reader(
     store: ObjectStore,
     path: str,
@@ -88,8 +93,19 @@ class ReadableFile:
         """
 
     @property
+    @deprecated(
+        "`ReadableFile.meta` is deprecated and will be removed in a future release. "
+        "Call `obstore.head(store, path)` directly if you need object metadata.",
+    )
     def meta(self) -> ObjectMeta:
-        """Access the metadata of the underlying file."""
+        """Access the metadata of the underlying file.
+
+        !!! warning "Deprecated"
+
+            This attribute is deprecated and will be removed in a future
+            release. Call [`obstore.head`][obstore.head] directly if you
+            need object metadata.
+        """
 
     def read(self, size: int | None = None, /) -> Bytes:
         """Read up to `size` bytes from the object and return them.
@@ -170,8 +186,19 @@ class AsyncReadableFile:
         """
 
     @property
+    @deprecated(
+        "`AsyncReadableFile.meta` is deprecated and will be removed in a future release. "
+        "Call `obstore.head_async(store, path)` directly if you need object metadata.",
+    )
     def meta(self) -> ObjectMeta:
-        """Access the metadata of the underlying file."""
+        """Access the metadata of the underlying file.
+
+        !!! warning "Deprecated"
+
+            This attribute is deprecated and will be removed in a future
+            release. Call [`obstore.head_async`][obstore.head_async]
+            directly if you need object metadata.
+        """
 
     async def read(self, size: int | None = None, /) -> Bytes:
         """Read up to `size` bytes from the object and return them.

--- a/obstore/python/obstore/_buffered.pyi
+++ b/obstore/python/obstore/_buffered.pyi
@@ -95,7 +95,7 @@ class ReadableFile:
     @property
     @deprecated(
         "`ReadableFile.meta` is deprecated and will be removed in a future release. "
-        "Call `obstore.head(store, path)` directly if you need object metadata.",
+        "Use the `head` or `head_async` methods directly if you need object metadata.",
     )
     def meta(self) -> ObjectMeta:
         """Access the metadata of the underlying file.
@@ -103,8 +103,9 @@ class ReadableFile:
         !!! warning "Deprecated"
 
             This attribute is deprecated and will be removed in a future
-            release. Call [`obstore.head`][obstore.head] directly if you
-            need object metadata.
+            release. Use the [`head`][obstore.head] or
+            [`head_async`][obstore.head_async] methods directly if you need
+            object metadata.
         """
 
     def read(self, size: int | None = None, /) -> Bytes:
@@ -188,7 +189,7 @@ class AsyncReadableFile:
     @property
     @deprecated(
         "`AsyncReadableFile.meta` is deprecated and will be removed in a future release. "
-        "Call `obstore.head_async(store, path)` directly if you need object metadata.",
+        "Use the `head` or `head_async` methods directly if you need object metadata.",
     )
     def meta(self) -> ObjectMeta:
         """Access the metadata of the underlying file.
@@ -196,8 +197,9 @@ class AsyncReadableFile:
         !!! warning "Deprecated"
 
             This attribute is deprecated and will be removed in a future
-            release. Call [`obstore.head_async`][obstore.head_async]
-            directly if you need object metadata.
+            release. Use the [`head`][obstore.head] or
+            [`head_async`][obstore.head_async] methods directly if you need
+            object metadata.
         """
 
     async def read(self, size: int | None = None, /) -> Bytes:

--- a/obstore/src/buffered.rs
+++ b/obstore/src/buffered.rs
@@ -96,7 +96,7 @@ impl PyReadableFile {
         let warnings_mod = py.import(intern!(py, "warnings"))?;
         let warning = PyDeprecationWarning::new_err(
             "The `meta` attribute is deprecated and will be removed in a future release. \
-             Call `obstore.head` (or `obstore.head_async`) directly if you need object metadata.",
+             Use the `head` or `head_async` methods directly if you need object metadata.",
         );
         warnings_mod.call_method1(intern!(py, "warn"), (warning,))?;
         Ok(self.meta.clone().into())

--- a/obstore/src/buffered.rs
+++ b/obstore/src/buffered.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 use object_store::buffered::{BufReader, BufWriter};
 use object_store::{ObjectMeta, ObjectStore, ObjectStoreExt};
-use pyo3::exceptions::{PyIOError, PyStopAsyncIteration, PyStopIteration};
+use pyo3::exceptions::{PyDeprecationWarning, PyIOError, PyStopAsyncIteration, PyStopIteration};
 use pyo3::prelude::*;
 use pyo3::types::PyString;
 use pyo3::{intern, IntoPyObjectExt};
@@ -92,8 +92,14 @@ impl PyReadableFile {
     fn close(&self) {}
 
     #[getter]
-    fn meta(&self) -> PyObjectMeta {
-        self.meta.clone().into()
+    fn meta(&self, py: Python) -> PyResult<PyObjectMeta> {
+        let warnings_mod = py.import(intern!(py, "warnings"))?;
+        let warning = PyDeprecationWarning::new_err(
+            "The `meta` attribute is deprecated and will be removed in a future release. \
+             Call `obstore.head` (or `obstore.head_async`) directly if you need object metadata.",
+        );
+        warnings_mod.call_method1(intern!(py, "warn"), (warning,))?;
+        Ok(self.meta.clone().into())
     }
 
     #[pyo3(signature = (size = None, /))]

--- a/tests/test_buffered.py
+++ b/tests/test_buffered.py
@@ -112,3 +112,30 @@ async def test_read_past_eof_async():
     buf = BytesIO(data)
     expected = buf.read(20)
     assert memoryview(expected) == memoryview(buffer)
+
+
+def test_readable_file_meta_emits_deprecation_warning():
+    store = MemoryStore()
+    path = "sized.bin"
+    obs.put(store, path, b"x" * 100)
+
+    file = obs.open_reader(store, path)
+    with pytest.warns(DeprecationWarning, match="`meta` attribute is deprecated"):
+        meta = file.meta
+
+    assert meta["size"] == 100
+    assert meta["path"] == path
+
+
+@pytest.mark.asyncio
+async def test_async_readable_file_meta_emits_deprecation_warning():
+    store = MemoryStore()
+    path = "sized.bin"
+    await obs.put_async(store, path, b"x" * 100)
+
+    file = await obs.open_reader_async(store, path)
+    with pytest.warns(DeprecationWarning, match="`meta` attribute is deprecated"):
+        meta = file.meta
+
+    assert meta["size"] == 100
+    assert meta["path"] == path


### PR DESCRIPTION
# Summary
Agreed on in [#664 (review comment)](https://github.com/developmentseed/obstore/pull/664#discussion_r3080675352).
Adds the deprecation warning now, so it can ship in a patch release: the actual removal + struct simplification stays on #664 for the next breaking release.

## Follow-up
The actual removal of `.meta` and the struct simplification to `{reader, size, r#async}` lives on #664 
