### PR TITLE
chore: Prepare obstore 0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## [0.9.5] - 2026-05-20
+
+### What's Changed
+
+- fix: Fix handling prefix during signing https://github.com/developmentseed/obstore/pull/683
+
+**Full Changelog**: https://github.com/developmentseed/obstore/compare/py-v0.9.4...py-v0.9.5
+
 ## [0.9.4] - 2026-04-22
 
 ### What's Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1363,7 +1363,7 @@ dependencies = [
 
 [[package]]
 name = "obstore"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "arrow",
  "bytes",

--- a/obstore/Cargo.toml
+++ b/obstore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "obstore"
-version = "0.9.4"
+version = "0.9.5"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "The simplest, highest-throughput interface to Amazon S3, Google Cloud Storage, Azure Blob Storage, and S3-compliant APIs like Cloudflare R2."


### PR DESCRIPTION
Update changelog and bump to 0.9.5