### PR TITLE
docs: Expose `read_timeout` client config

### DIFF
--- a/obstore/python/obstore/_store/_client.pyi
+++ b/obstore/python/obstore/_store/_client.pyi
@@ -94,6 +94,18 @@ class ClientConfig(TypedDict, total=False):
 
     """
 
+    read_timeout: str | timedelta
+    """Read timeout.
+
+    The timeout applies to each read operation, and resets after a
+    successful read. This is useful for detecting stalled connections
+    when the size of the response is not known beforehand.
+
+    Timeout errors are retried, subject to the `RetryConfig`.
+
+    Default is disabled (no read timeout).
+    """
+
     """HTTP proxy to use for requests."""
     timeout: str | timedelta
     """Request timeout.


### PR DESCRIPTION
Reflects upstream https://github.com/apache/arrow-rs-object-store/pull/681

See #686 