### PR TITLE
feat: Make ObjectStoreMethods public, update docs

### DIFF
--- a/docs/api/copy.md
+++ b/docs/api/copy.md
@@ -1,4 +1,11 @@
 # Copy
 
+## Method API
+
+::: obstore.store.ObjectStoreMixin.copy
+::: obstore.store.ObjectStoreMixin.copy_async
+
+## Functional API
+
 ::: obstore.copy
 ::: obstore.copy_async

--- a/docs/api/copy.md
+++ b/docs/api/copy.md
@@ -1,5 +1,9 @@
 # Copy
 
+Copy operations.
+
+Obstore provides [two API designs](../method-vs-functional-api.md) for your convenience.
+
 ## Method API
 
 ::: obstore.store.ObjectStoreMethods.copy

--- a/docs/api/copy.md
+++ b/docs/api/copy.md
@@ -2,8 +2,8 @@
 
 ## Method API
 
-::: obstore.store.ObjectStoreMixin.copy
-::: obstore.store.ObjectStoreMixin.copy_async
+::: obstore.store.ObjectStoreMethods.copy
+::: obstore.store.ObjectStoreMethods.copy_async
 
 ## Functional API
 

--- a/docs/api/delete.md
+++ b/docs/api/delete.md
@@ -1,5 +1,9 @@
 # Delete
 
+Delete operations.
+
+Obstore provides [two API designs](../method-vs-functional-api.md) for your convenience.
+
 ## Method API
 
 ::: obstore.store.ObjectStoreMethods.delete

--- a/docs/api/delete.md
+++ b/docs/api/delete.md
@@ -1,4 +1,11 @@
 # Delete
 
+## Method API
+
+::: obstore.store.ObjectStoreMixin.delete
+::: obstore.store.ObjectStoreMixin.delete_async
+
+## Functional API
+
 ::: obstore.delete
 ::: obstore.delete_async

--- a/docs/api/delete.md
+++ b/docs/api/delete.md
@@ -2,8 +2,8 @@
 
 ## Method API
 
-::: obstore.store.ObjectStoreMixin.delete
-::: obstore.store.ObjectStoreMixin.delete_async
+::: obstore.store.ObjectStoreMethods.delete
+::: obstore.store.ObjectStoreMethods.delete_async
 
 ## Functional API
 

--- a/docs/api/file.md
+++ b/docs/api/file.md
@@ -4,6 +4,8 @@ Native support for reading from object stores as a file-like object.
 
 Use `obstore.open_reader` or `obstore.open_reader_async` to open readable files. Use `obstore.open_writer` or `obstore.open_writer_async` to open writable files.
 
+See [ReadableFile][obstore.ReadableFile] and [AsyncReadableFile][obstore.AsyncReadableFile] for more information on caching behavior.
+
 ::: obstore.open_reader
 ::: obstore.open_reader_async
 ::: obstore.open_writer

--- a/docs/api/get.md
+++ b/docs/api/get.md
@@ -1,5 +1,9 @@
 # Get
 
+Get operations.
+
+Obstore provides [two API designs](../method-vs-functional-api.md) for your convenience.
+
 ## Method API
 
 ::: obstore.store.ObjectStoreMethods.get

--- a/docs/api/get.md
+++ b/docs/api/get.md
@@ -2,12 +2,12 @@
 
 ## Method API
 
-::: obstore.store.ObjectStoreMixin.get
-::: obstore.store.ObjectStoreMixin.get_async
-::: obstore.store.ObjectStoreMixin.get_range
-::: obstore.store.ObjectStoreMixin.get_range_async
-::: obstore.store.ObjectStoreMixin.get_ranges
-::: obstore.store.ObjectStoreMixin.get_ranges_async
+::: obstore.store.ObjectStoreMethods.get
+::: obstore.store.ObjectStoreMethods.get_async
+::: obstore.store.ObjectStoreMethods.get_range
+::: obstore.store.ObjectStoreMethods.get_range_async
+::: obstore.store.ObjectStoreMethods.get_ranges
+::: obstore.store.ObjectStoreMethods.get_ranges_async
 
 ## Functional API
 

--- a/docs/api/get.md
+++ b/docs/api/get.md
@@ -1,11 +1,25 @@
 # Get
 
+## Method API
+
+::: obstore.store.ObjectStoreMixin.get
+::: obstore.store.ObjectStoreMixin.get_async
+::: obstore.store.ObjectStoreMixin.get_range
+::: obstore.store.ObjectStoreMixin.get_range_async
+::: obstore.store.ObjectStoreMixin.get_ranges
+::: obstore.store.ObjectStoreMixin.get_ranges_async
+
+## Functional API
+
 ::: obstore.get
 ::: obstore.get_async
 ::: obstore.get_range
 ::: obstore.get_range_async
 ::: obstore.get_ranges
 ::: obstore.get_ranges_async
+
+## Types
+
 ::: obstore.GetOptions
 ::: obstore.GetResult
 ::: obstore.BytesStream

--- a/docs/api/head.md
+++ b/docs/api/head.md
@@ -2,8 +2,8 @@
 
 ## Method API
 
-::: obstore.store.ObjectStoreMixin.head
-::: obstore.store.ObjectStoreMixin.head_async
+::: obstore.store.ObjectStoreMethods.head
+::: obstore.store.ObjectStoreMethods.head_async
 
 ## Functional API
 

--- a/docs/api/head.md
+++ b/docs/api/head.md
@@ -1,5 +1,9 @@
 # Head
 
+Head operations.
+
+Obstore provides [two API designs](../method-vs-functional-api.md) for your convenience.
+
 ## Method API
 
 ::: obstore.store.ObjectStoreMethods.head

--- a/docs/api/head.md
+++ b/docs/api/head.md
@@ -1,4 +1,11 @@
 # Head
 
+## Method API
+
+::: obstore.store.ObjectStoreMixin.head
+::: obstore.store.ObjectStoreMixin.head_async
+
+## Functional API
+
 ::: obstore.head
 ::: obstore.head_async

--- a/docs/api/list.md
+++ b/docs/api/list.md
@@ -1,8 +1,19 @@
 # List
 
+## Method API
+
+::: obstore.store.ObjectStoreMixin.list
+::: obstore.store.ObjectStoreMixin.list_with_delimiter
+::: obstore.store.ObjectStoreMixin.list_with_delimiter_async
+
+## Functional API
+
 ::: obstore.list
 ::: obstore.list_with_delimiter
 ::: obstore.list_with_delimiter_async
+
+## Types
+
 ::: obstore.ObjectMeta
 ::: obstore.ListResult
 ::: obstore.ListStream

--- a/docs/api/list.md
+++ b/docs/api/list.md
@@ -2,9 +2,9 @@
 
 ## Method API
 
-::: obstore.store.ObjectStoreMixin.list
-::: obstore.store.ObjectStoreMixin.list_with_delimiter
-::: obstore.store.ObjectStoreMixin.list_with_delimiter_async
+::: obstore.store.ObjectStoreMethods.list
+::: obstore.store.ObjectStoreMethods.list_with_delimiter
+::: obstore.store.ObjectStoreMethods.list_with_delimiter_async
 
 ## Functional API
 

--- a/docs/api/list.md
+++ b/docs/api/list.md
@@ -1,5 +1,9 @@
 # List
 
+List operations.
+
+Obstore provides [two API designs](../method-vs-functional-api.md) for your convenience.
+
 ## Method API
 
 ::: obstore.store.ObjectStoreMethods.list

--- a/docs/api/put.md
+++ b/docs/api/put.md
@@ -1,7 +1,17 @@
 # Put
 
+## Method API
+
+::: obstore.store.ObjectStoreMixin.put
+::: obstore.store.ObjectStoreMixin.put_async
+
+## Functional API
+
 ::: obstore.put
 ::: obstore.put_async
+
+## Types
+
 ::: obstore.PutResult
 ::: obstore.UpdateVersion
 ::: obstore.PutMode

--- a/docs/api/put.md
+++ b/docs/api/put.md
@@ -1,5 +1,9 @@
 # Put
 
+Put operations.
+
+Obstore provides [two API designs](../method-vs-functional-api.md) for your convenience.
+
 ## Method API
 
 ::: obstore.store.ObjectStoreMethods.put

--- a/docs/api/put.md
+++ b/docs/api/put.md
@@ -2,8 +2,8 @@
 
 ## Method API
 
-::: obstore.store.ObjectStoreMixin.put
-::: obstore.store.ObjectStoreMixin.put_async
+::: obstore.store.ObjectStoreMethods.put
+::: obstore.store.ObjectStoreMethods.put_async
 
 ## Functional API
 

--- a/docs/api/rename.md
+++ b/docs/api/rename.md
@@ -2,8 +2,8 @@
 
 ## Method API
 
-::: obstore.store.ObjectStoreMixin.rename
-::: obstore.store.ObjectStoreMixin.rename_async
+::: obstore.store.ObjectStoreMethods.rename
+::: obstore.store.ObjectStoreMethods.rename_async
 
 ## Functional API
 

--- a/docs/api/rename.md
+++ b/docs/api/rename.md
@@ -1,4 +1,11 @@
 # Rename
 
+## Method API
+
+::: obstore.store.ObjectStoreMixin.rename
+::: obstore.store.ObjectStoreMixin.rename_async
+
+## Functional API
+
 ::: obstore.rename
 ::: obstore.rename_async

--- a/docs/api/rename.md
+++ b/docs/api/rename.md
@@ -1,5 +1,9 @@
 # Rename
 
+Rename operations.
+
+Obstore provides [two API designs](../method-vs-functional-api.md) for your convenience.
+
 ## Method API
 
 ::: obstore.store.ObjectStoreMethods.rename

--- a/docs/api/store/aws.md
+++ b/docs/api/store/aws.md
@@ -3,7 +3,6 @@
 ::: obstore.store.S3Store
     options:
         inherited_members: true
-        show_bases: false
 ::: obstore.store.S3Config
     options:
         show_if_no_docstring: true

--- a/docs/api/store/azure.md
+++ b/docs/api/store/azure.md
@@ -3,7 +3,6 @@
 ::: obstore.store.AzureStore
     options:
         inherited_members: true
-        show_bases: false
 ::: obstore.store.AzureConfig
     options:
         show_if_no_docstring: true

--- a/docs/api/store/base.md
+++ b/docs/api/store/base.md
@@ -1,5 +1,0 @@
-# Base ObjectStore methods
-
-::: obstore.store.ObjectStoreMixin
-    options:
-        inherited_members: true

--- a/docs/api/store/base.md
+++ b/docs/api/store/base.md
@@ -1,0 +1,5 @@
+# Base ObjectStore methods
+
+::: obstore.store.ObjectStoreMixin
+    options:
+        inherited_members: true

--- a/docs/api/store/gcs.md
+++ b/docs/api/store/gcs.md
@@ -3,7 +3,6 @@
 ::: obstore.store.GCSStore
     options:
         inherited_members: true
-        show_bases: false
 ::: obstore.store.GCSConfig
     options:
         show_if_no_docstring: true

--- a/docs/api/store/http.md
+++ b/docs/api/store/http.md
@@ -3,4 +3,3 @@
 ::: obstore.store.HTTPStore
     options:
         inherited_members: true
-        show_bases: false

--- a/docs/api/store/index.md
+++ b/docs/api/store/index.md
@@ -2,3 +2,8 @@
 
 ::: obstore.store.from_url
 ::: obstore.store.ObjectStore
+<!-- We document each actual method in the method-specific pages. -->
+::: obstore.store.ObjectStoreMethods
+    options:
+      members:
+        - false

--- a/docs/api/store/local.md
+++ b/docs/api/store/local.md
@@ -3,4 +3,3 @@
 ::: obstore.store.LocalStore
     options:
         inherited_members: true
-        show_bases: false

--- a/docs/api/store/memory.md
+++ b/docs/api/store/memory.md
@@ -3,4 +3,3 @@
 ::: obstore.store.MemoryStore
     options:
         inherited_members: true
-        show_bases: false

--- a/docs/method-vs-functional-api.md
+++ b/docs/method-vs-functional-api.md
@@ -1,0 +1,48 @@
+# Method vs Functional API
+
+Obstore presents two **nearly-identical APIs** for user convenience, a [method-based API](#method-based-api) and a [functional API](#functional-api).
+
+## Method-based API
+
+The method-based API allows for using methods on store classes.
+
+```py
+from obstore.store import S3Store
+
+store = S3Store("bucket", ...)
+buffer = store.get_range("path", start=0, end=16384)
+```
+
+This is slightly cleaner to use and less verbose than the functional API.
+
+### Obspec compatibility
+
+We also prefer the method-based API because it integrates with [Obspec], generic protocols that define the Object Storage interface. This makes it possible to write code once that works with Obstore and other arbitrary backends.
+
+See the [sibling user guide page](obspec.md) and [Obspec documentation][Obspec] for more information.
+
+[Obspec]: https://developmentseed.org/obspec/
+
+## Functional API
+
+The functional API provides top-level functions to interact with obstore operations.
+
+```py
+import obstore as obs
+from obstore.store import S3Store
+
+store = S3Store("bucket", ...)
+buffer = obs.get_range(store, "path", start=0, end=16384)
+```
+
+## Differences
+
+The main difference between the two APIs is verbosity: the functional API is more verbose because it requires passing `store` as an argument into each operation.
+
+#### Signed URLs
+
+[Creating signed URLs](api/sign.md) is only supported via the functional API because not all object stores support signing.
+
+#### File-like Objects
+
+[Creating file-like objects](api/file.md) is only supported via the functional API because we want to slightly nudge users away from that behavior, if it's possible to achieve their goals with native methods, which should provide better performance.

--- a/docs/obspec.md
+++ b/docs/obspec.md
@@ -1,11 +1,36 @@
 # Generic storage abstractions with Obspec
 
-Obstore provides an implementation for accessing Amazon S3, Google Cloud Storage, and Azure Storage, but some libraries may want to also support other backends, such as HTTP clients or more obscure things like SFTP or HDFS filesystems.
+Obstore supports Amazon S3, Google Cloud Storage, and Azure Storage, but some libraries may want to also support other backends, such as HTTP clients or more obscure things like SFTP or HDFS filesystems.
 
-Additionally, there's a bunch of useful behavior that could exist on top of Obstore: caching, metrics, globbing, bulk operations. While all of those operations are useful, we want to keep the core Obstore library as small as possible, tightly coupled with the underlying Rust `object_store` library.
+Additionally, there's a bunch of useful behavior that could exist on top of Obstore stores: caching, metrics, globbing, bulk operations. While all of those operations are useful, we want to keep the core Obstore library as small as possible, tightly coupled with the underlying Rust `object_store` library.
 
 [Obspec](https://developmentseed.org/obspec/) exists to provide the abstractions for generic programming against object store backends. Obspec is essentially a formalization and generalization of the Obstore API, so if you're already using Obstore, very few changes are needed to use Obspec instead.
 
 Downstream libraries can program against the Obspec API to be fully generic around what underlying backend is used at runtime.
+
+## Example
+
+To download a file generically, depend on the [Get][obspec.Get] protocol, which defines a `get` method.
+
+```py
+from obspec import Get
+
+def download_file(client: Get):
+    response = client.get("my-file.txt")
+    for buffer in response:
+        # Process each buffer chunk as needed
+        print(f"Received buffer of size: {len(memoryview(buffer))} bytes")
+```
+
+All Obstore stores implement the Obspec protocol. So you can now pass:
+
+```py
+from obstore.store import S3Store
+
+store = S3Store("bucket", ...)
+download_file(store)
+```
+
+## More Information
 
 For further information, refer to the [Obspec documentation](https://developmentseed.org/obspec/latest/) and the [Obspec announcement blog post](https://developmentseed.org/obspec/latest/blog/2025/06/25/introducing-obspec-a-python-protocol-for-interfacing-with-object-storage/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
   - API Reference:
       - obstore.store:
           - api/store/index.md
+          - api/store/base.md
           - api/store/aws.md
           - api/store/gcs.md
           - api/store/azure.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
   - User Guide:
       - getting-started.md
       - cookbook.md
+      - method-vs-functional-api.md
       - authentication.md
       - obspec.md
       - Integrations:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,7 +49,6 @@ nav:
   - API Reference:
       - obstore.store:
           - api/store/index.md
-          - api/store/base.md
           - api/store/aws.md
           - api/store/gcs.md
           - api/store/azure.md

--- a/obstore/python/obstore/store.py
+++ b/obstore/python/obstore/store.py
@@ -98,7 +98,7 @@ __all__ = [
 ]
 
 
-class _ObjectStoreMixin:
+class ObjectStoreMixin:
     def copy(self, from_: str, to: str, *, overwrite: bool = True) -> None:
         """Copy an object from one path to another in the same object store.
 
@@ -579,7 +579,7 @@ class _ObjectStoreMixin:
         )
 
 
-class AzureStore(_ObjectStoreMixin, _store.AzureStore):
+class AzureStore(ObjectStoreMixin, _store.AzureStore):
     """Interface to a Microsoft Azure Blob Storage container.
 
     All constructors will check for environment variables. Refer to
@@ -587,7 +587,7 @@ class AzureStore(_ObjectStoreMixin, _store.AzureStore):
     """
 
 
-class GCSStore(_ObjectStoreMixin, _store.GCSStore):
+class GCSStore(ObjectStoreMixin, _store.GCSStore):
     """Interface to Google Cloud Storage.
 
     All constructors will check for environment variables. Refer to
@@ -599,7 +599,7 @@ class GCSStore(_ObjectStoreMixin, _store.GCSStore):
     """
 
 
-class HTTPStore(_ObjectStoreMixin, _store.HTTPStore):
+class HTTPStore(ObjectStoreMixin, _store.HTTPStore):
     """Configure a connection to a generic HTTP server.
 
     **Example**
@@ -627,7 +627,7 @@ class HTTPStore(_ObjectStoreMixin, _store.HTTPStore):
     """
 
 
-class LocalStore(_ObjectStoreMixin, _store.LocalStore):
+class LocalStore(ObjectStoreMixin, _store.LocalStore):
     """An ObjectStore interface to local filesystem storage.
 
     Can optionally be created with a directory prefix.
@@ -642,7 +642,7 @@ class LocalStore(_ObjectStoreMixin, _store.LocalStore):
     """
 
 
-class MemoryStore(_ObjectStoreMixin, _store.MemoryStore):
+class MemoryStore(ObjectStoreMixin, _store.MemoryStore):
     """A fully in-memory implementation of ObjectStore.
 
     Create a new in-memory store:
@@ -652,7 +652,7 @@ class MemoryStore(_ObjectStoreMixin, _store.MemoryStore):
     """
 
 
-class S3Store(_ObjectStoreMixin, _store.S3Store):
+class S3Store(ObjectStoreMixin, _store.S3Store):
     """Interface to an Amazon S3 bucket.
 
     All constructors will check for environment variables. Refer to

--- a/obstore/python/obstore/store.py
+++ b/obstore/python/obstore/store.py
@@ -99,6 +99,22 @@ __all__ = [
 
 
 class ObjectStoreMethods:
+    """Shared methods implemented by all obstore store classes.
+
+    This is the concrete method surface common to [`S3Store`][obstore.store.S3Store],
+    [`AzureStore`][obstore.store.AzureStore], [`GCSStore`][obstore.store.GCSStore],
+    [`HTTPStore`][obstore.store.HTTPStore], [`LocalStore`][obstore.store.LocalStore],
+    and [`MemoryStore`][obstore.store.MemoryStore].
+
+    It is exposed for documentation and for
+    `isinstance` checks against obstore's own stores.
+
+    !!! note
+        Do not subclass this to build your own store. To implement a
+        custom object store backend, implement the protocols in
+        [obspec](https://developmentseed.org/obspec/) instead.
+    """
+
     def copy(self, from_: str, to: str, *, overwrite: bool = True) -> None:
         """Copy an object from one path to another in the same object store.
 

--- a/obstore/python/obstore/store.py
+++ b/obstore/python/obstore/store.py
@@ -98,7 +98,7 @@ __all__ = [
 ]
 
 
-class ObjectStoreMixin:
+class ObjectStoreMethods:
     def copy(self, from_: str, to: str, *, overwrite: bool = True) -> None:
         """Copy an object from one path to another in the same object store.
 
@@ -579,7 +579,7 @@ class ObjectStoreMixin:
         )
 
 
-class AzureStore(ObjectStoreMixin, _store.AzureStore):
+class AzureStore(ObjectStoreMethods, _store.AzureStore):
     """Interface to a Microsoft Azure Blob Storage container.
 
     All constructors will check for environment variables. Refer to
@@ -587,7 +587,7 @@ class AzureStore(ObjectStoreMixin, _store.AzureStore):
     """
 
 
-class GCSStore(ObjectStoreMixin, _store.GCSStore):
+class GCSStore(ObjectStoreMethods, _store.GCSStore):
     """Interface to Google Cloud Storage.
 
     All constructors will check for environment variables. Refer to
@@ -599,7 +599,7 @@ class GCSStore(ObjectStoreMixin, _store.GCSStore):
     """
 
 
-class HTTPStore(ObjectStoreMixin, _store.HTTPStore):
+class HTTPStore(ObjectStoreMethods, _store.HTTPStore):
     """Configure a connection to a generic HTTP server.
 
     **Example**
@@ -627,7 +627,7 @@ class HTTPStore(ObjectStoreMixin, _store.HTTPStore):
     """
 
 
-class LocalStore(ObjectStoreMixin, _store.LocalStore):
+class LocalStore(ObjectStoreMethods, _store.LocalStore):
     """An ObjectStore interface to local filesystem storage.
 
     Can optionally be created with a directory prefix.
@@ -642,7 +642,7 @@ class LocalStore(ObjectStoreMixin, _store.LocalStore):
     """
 
 
-class MemoryStore(ObjectStoreMixin, _store.MemoryStore):
+class MemoryStore(ObjectStoreMethods, _store.MemoryStore):
     """A fully in-memory implementation of ObjectStore.
 
     Create a new in-memory store:
@@ -652,7 +652,7 @@ class MemoryStore(ObjectStoreMixin, _store.MemoryStore):
     """
 
 
-class S3Store(ObjectStoreMixin, _store.S3Store):
+class S3Store(ObjectStoreMethods, _store.S3Store):
     """Interface to an Amazon S3 bucket.
 
     All constructors will check for environment variables. Refer to

--- a/obstore/python/obstore/store.py
+++ b/obstore/python/obstore/store.py
@@ -109,6 +109,8 @@ class ObjectStoreMethods:
     It is exposed for documentation and for
     `isinstance` checks against obstore's own stores.
 
+    This implements the protocols defined in [obspec](https://developmentseed.org/obspec/).
+
     !!! note
         Do not subclass this to build your own store. To implement a
         custom object store backend, implement the protocols in

--- a/obstore/python/obstore/store.py
+++ b/obstore/python/obstore/store.py
@@ -138,7 +138,7 @@ class ObjectStoreMethods:
     ) -> None:
         """Call `copy` asynchronously.
 
-        Refer to the documentation for [copy][obstore.copy].
+        Refer to the documentation for [copy_async][obstore.copy_async].
         """
         return await obs.copy_async(
             self,  # type: ignore[arg-type]
@@ -160,7 +160,7 @@ class ObjectStoreMethods:
     async def delete_async(self, paths: str | Sequence[str]) -> None:
         """Call `delete` asynchronously.
 
-        Refer to the documentation for [delete][obstore.delete].
+        Refer to the documentation for [delete_async][obstore.delete_async].
         """
         return await obs.delete_async(
             self,  # type: ignore[arg-type]
@@ -191,7 +191,7 @@ class ObjectStoreMethods:
     ) -> GetResult:
         """Call `get` asynchronously.
 
-        Refer to the documentation for [get][obstore.get].
+        Refer to the documentation for [get_async][obstore.get_async].
         """
         return await obs.get_async(
             self,  # type: ignore[arg-type]
@@ -229,7 +229,7 @@ class ObjectStoreMethods:
     ) -> Bytes:
         """Call `get_range` asynchronously.
 
-        Refer to the documentation for [get_range][obstore.get_range].
+        Refer to the documentation for [get_range_async][obstore.get_range_async].
         """
         return await obs.get_range_async(
             self,  # type: ignore[arg-type]
@@ -272,7 +272,7 @@ class ObjectStoreMethods:
     ) -> list[Bytes]:
         """Call `get_ranges` asynchronously.
 
-        Refer to the documentation for [get_ranges][obstore.get_ranges].
+        Refer to the documentation for [get_ranges_async][obstore.get_ranges_async].
         """
         return await obs.get_ranges_async(
             self,  # type: ignore[arg-type]
@@ -471,7 +471,7 @@ class ObjectStoreMethods:
         """Call `list_with_delimiter` asynchronously.
 
         Refer to the documentation for
-        [list_with_delimiter][obstore.list_with_delimiter].
+        [list_with_delimiter_async][obstore.list_with_delimiter_async].
         """
         # Splitting these fixes the typing issue with the `return_arrow` parameter, by
         # converting from a bool to a Literal[True] or Literal[False]
@@ -537,22 +537,7 @@ class ObjectStoreMethods:
     ) -> PutResult:
         """Call `put` asynchronously.
 
-        Refer to the documentation for [`put`][obstore.put]. In addition to what the
-        synchronous `put` allows for the `file` parameter, this **also supports an async
-        iterator or iterable** of objects implementing the Python buffer protocol.
-
-        This means, for example, you can pass the result of `get_async` directly to
-        `put_async`, and the request will be streamed through Python during the put
-        operation:
-
-        ```py
-        import obstore as obs
-
-        # This only constructs the stream, it doesn't materialize the data in memory
-        resp = await obs.get_async(store1, path1)
-        # A streaming upload is created to copy the file to path2
-        await obs.put_async(store2, path2)
-        ```
+        Refer to the documentation for [put_async][obstore.put_async].
         """
         return await obs.put_async(
             self,  # type: ignore[arg-type]
@@ -587,7 +572,7 @@ class ObjectStoreMethods:
     ) -> None:
         """Call `rename` asynchronously.
 
-        Refer to the documentation for [rename][obstore.rename].
+        Refer to the documentation for [rename_async][obstore.rename_async].
         """
         return await obs.rename_async(
             self,  # type: ignore[arg-type]


### PR DESCRIPTION
Closes https://github.com/developmentseed/obstore/issues/634

The docstring tries to document that this should not be implemented by end users.