### PR TITLE
fix: resolve relative local paths in FsspecStore('file')

### DIFF
--- a/obstore/python/obstore/fsspec.py
+++ b/obstore/python/obstore/fsspec.py
@@ -42,6 +42,7 @@ from urllib.parse import urlparse
 
 import fsspec.asyn
 import fsspec.spec
+from fsspec.implementations.local import make_path_posix
 
 from obstore import open_reader, open_writer
 from obstore.store import from_url
@@ -296,9 +297,14 @@ class FsspecStore(fsspec.asyn.AsyncFileSystem):
 
         # If the protocol doesn't require buckets, return empty bucket and full path
         if self.protocol in protocol_without_bucket:
+            parsed_path = (
+                f"{parsed.netloc}/{parsed.path.lstrip('/')}" if parsed.scheme else path
+            )
+            if self.protocol == "file":
+                parsed_path = str(make_path_posix(parsed_path))
             return (
                 "",
-                f"{parsed.netloc}/{parsed.path.lstrip('/')}" if parsed.scheme else path,
+                parsed_path,
             )
 
         if parsed.scheme:
@@ -466,7 +472,6 @@ class FsspecStore(fsspec.asyn.AsyncFileSystem):
         mode: str = "overwrite",  # noqa: ARG002
         **_kwargs: Any,
     ) -> None:
-
         if not await self._local_store._exists(lpath):  # noqa: SLF001
             raise FileNotFoundError(lpath)
 

--- a/tests/test_fsspec.py
+++ b/tests/test_fsspec.py
@@ -296,6 +296,19 @@ def test_split_path(fs: FsspecStore):
     )
     assert file_fs._split_path("/data-bucket/") == ("", "/data-bucket/")
 
+    # relative path, without bucket -> resolved to absolute for the "file" protocol
+    rel_bucket, rel_path = file_fs._split_path("relative/path/to/file")
+    assert rel_bucket == ""
+    assert Path(rel_path).is_absolute()
+    assert rel_path.endswith("relative/path/to/file")
+
+    # memory protocol keeps relative paths untouched (paths are virtual)
+    memory_fs = FsspecStore("memory")  # type: ignore (no __init__ overload for memory)
+    assert memory_fs._split_path("relative/path/to/file") == (
+        "",
+        "relative/path/to/file",
+    )
+
 
 def test_list(
     minio_bucket: tuple[S3Config, ClientConfig],


### PR DESCRIPTION
Since `0.9.3`, the fsspec integration routes the local side of `_get_file` / `_put_file` through a `LocalStore` (`FsspecStore("file")`), per #258 / #656. That `LocalStore` is backed by `object_store`'s `LocalFileSystem`, which only accepts **absolute** paths. As a result, passing a **relative** local path to `get`/`put` now fails, whereas it worked before `0.9.3` (when these methods used plain Python file handles).

This affects the common case `fs.put("local.txt", "bucket/key")` when the local path is relative to the current working directory.

Closes https://github.com/developmentseed/obstore/issues/711.

### Reproduction

```python
import os
from obstore.fsspec import FsspecStore

# any remote store works; using S3 for illustration
fs = FsspecStore("s3", config=..., client_options=...)

os.chdir("/tmp")
with open("local.txt", "w") as f:
    f.write("hello")

# relative local path -> fails
fs.put_file("local.txt", "my-bucket/key.txt")
```

Using an **absolute** local path (`/tmp/local.txt`) works.

### Expected behavior

Relative local paths should be resolved against the current working directory, matching:
- the behavior of `FsspecStore` before `0.9.3`, and
- the reference `LocalFileSystem` in fsspec, which accepts relative paths.

### Fix

Normalize the path in `_split_path` for the `file` protocol, using fsspec's own `make_path_posix` — the same function `LocalFileSystem` uses in `_strip_protocol`. This keeps `FsspecStore("file")` aligned with `LocalFileSystem` and keeps all path handling in the fsspec layer, without adding any semantics to the `object_store` rust layer (discussion in https://github.com/developmentseed/obstore/issues/711).

`_split_path` is the single funnel for `_exists` / `_isdir` / `_pipe_file` / `_cat_file` on the local store, so this one change fixes both `get` and `put`. `memory` (the other bucket-less protocol) is intentionally left untouched, since its keys are virtual and must not be resolved against the real working directory.

```python
if self.protocol in protocol_without_bucket:
    parsed_path = (
        f"{parsed.netloc}/{parsed.path.lstrip('/')}" if parsed.scheme else path
    )
    if self.protocol == "file":
        parsed_path = str(make_path_posix(parsed_path))
    return ("", parsed_path)
```

`make_path_posix` is imported from `fsspec.implementations.local` (fsspec is already a hard dependency).

### Tests

- relative `file` path resolves to an absolute path
- `memory` paths stay relative (guards the gating)
- relative-path `put` + `get` round-trip (the original repro)

### Environment

- obstore: 0.9.3+ (regression introduced in 0.9.3)
- OS: any
