### PR TITLE
perf: reuse self as local store for the file protocol in fsspec

### DIFF
--- a/obstore/python/obstore/fsspec.py
+++ b/obstore/python/obstore/fsspec.py
@@ -273,6 +273,9 @@ class FsspecStore(fsspec.asyn.AsyncFileSystem):
 
     @cached_property
     def _local_store(self) -> FsspecStore:
+        if self.protocol == "file":
+            # short circuit to avoid making new store when not needed
+            return self
         return FsspecStore("file")
 
     def _split_path(self, path: str) -> tuple[str, str]:
@@ -466,7 +469,6 @@ class FsspecStore(fsspec.asyn.AsyncFileSystem):
         mode: str = "overwrite",  # noqa: ARG002
         **_kwargs: Any,
     ) -> None:
-
         if not await self._local_store._exists(lpath):  # noqa: SLF001
             raise FileNotFoundError(lpath)
 


### PR DESCRIPTION
Small follow-up to the relative-path fix (#712): optimize `_local_store` so it doesn't construct a redundant store when the instance is already the local (`file`) protocol.

`_local_store` is used for the local side of `get`/`put` and is always a `FsspecStore("file")`. When `self` is already a `file`-protocol store, building a second `FsspecStore("file")` is wasted work — we can just reuse `self`. This also preserves the instance's `config`/`client_options` instead of discarding them in a freshly constructed default store.

```python
@cached_property
def _local_store(self) -> FsspecStore:
    if self.protocol == "file":
        # short circuit to avoid making new store when not needed
        return self
    return FsspecStore("file")
```

Suggested by @matteomorlack in #711.
