### PR TITLE
chore: Bump pyo3-object-store to 0.11

### DIFF
--- a/pyo3-object_store/CHANGELOG.md
+++ b/pyo3-object_store/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## [0.10.0] - 2026-06-15
+## [0.11.0] - 2026-06-15
 
 - Bump to pyo3 0.29.
+
+## [0.10.0] - 2026-02-09
+
+- Compatibility release with pyo3 0.28 and object_store 0.12.
 
 ## [0.9.0] - 2026-02-09
 

--- a/pyo3-object_store/Cargo.toml
+++ b/pyo3-object_store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-object_store"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Kyle Barron <kyle@developmentseed.org>"]
 edition = "2021"
 description = "object_store integration for pyo3."

--- a/pyo3-object_store/README.md
+++ b/pyo3-object_store/README.md
@@ -73,6 +73,7 @@ We don't yet have a _great_ solution here for reusing the store builder type hin
 | 0.7.x             | 0.27               | 0.12               |
 | 0.8.x             | 0.27               | 0.13               |
 | 0.9.x             | 0.28               | 0.13               |
-| 0.10.x            | 0.29               | 0.13               |
+| 0.10.x            | 0.28               | **0.12** :warning: |
+| 0.11.x            | 0.29               | 0.13               |
 
-Note that 0.3.x and 0.4.x are compatibility releases to use `pyo3-object_store` with older versions of `pyo3` and `object_store`.
+Note that 0.3.x, 0.4.x, and 0.10.x are compatibility releases to use `pyo3-object_store` with older versions of `pyo3` and `object_store`.


### PR DESCRIPTION
I'd forgotten that we already made a 0.10 compatibility release from a branch: https://github.com/developmentseed/obstore/commit/769877d791e0baf041ea94adcf148233f8930439