### PR TITLE
chore: Bump object_store to 0.14 in pyo3-object_store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,6 +1550,7 @@ dependencies = [
 [[package]]
 name = "pyo3-object_store"
 version = "0.11.0"
+source = "git+https://github.com/developmentseed/obstore?rev=fae2678c600fdc3b4b2da77d581aa25bbabfa31e#fae2678c600fdc3b4b2da77d581aa25bbabfa31e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2324,9 +2325,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"

--- a/obstore/Cargo.toml
+++ b/obstore/Cargo.toml
@@ -35,7 +35,8 @@ pyo3-arrow = "0.19"
 pyo3-async-runtimes = { workspace = true, features = ["tokio-runtime"] }
 pyo3-bytes = "0.7"
 pyo3-file = { workspace = true }
-pyo3-object_store = { path = "../pyo3-object_store" }
+# pyo3-object_store = { path = "../pyo3-object_store" }
+pyo3-object_store = { git = "https://github.com/developmentseed/obstore", rev = "fae2678c600fdc3b4b2da77d581aa25bbabfa31e" }
 tokio = { workspace = true, features = [
     "macros",
     "rt",

--- a/pyo3-object_store/Cargo.toml
+++ b/pyo3-object_store/Cargo.toml
@@ -27,8 +27,8 @@ humantime = "2.1"
 # This is already an object_store dependency
 http = "1"
 # This is already an object_store dependency
-itertools = "0.14.0"
-object_store = { version = "0.13.0", features = [
+itertools = "0.15.0"
+object_store = { version = "0.14.0", features = [
     "aws",
     "azure",
     "gcp",

--- a/pyo3-object_store/src/prefix.rs
+++ b/pyo3-object_store/src/prefix.rs
@@ -5,7 +5,7 @@
 
 use bytes::Bytes;
 use futures::{stream::BoxStream, StreamExt, TryStreamExt};
-use http::Method;
+use http::{Extensions, Method};
 use object_store::signer::Signer;
 use std::borrow::Cow;
 use std::future::Future;
@@ -193,6 +193,7 @@ impl<T: ObjectStore> ObjectStore for MaybePrefixedStore<T> {
                     .into_iter()
                     .map(|meta| self.strip_meta(meta))
                     .collect(),
+                extensions: Extensions::default(),
             })
     }
 


### PR DESCRIPTION
Update versions