### PR TITLE
chore: Bump pyo3 object_store to 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "pyo3-object_store"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/pyo3-object_store/CHANGELOG.md
+++ b/pyo3-object_store/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.12.0] - 2026-06-25
+
+- Bump to object_store 0.14
+
 ## [0.11.0] - 2026-06-15
 
 - Bump to pyo3 0.29.

--- a/pyo3-object_store/Cargo.toml
+++ b/pyo3-object_store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-object_store"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Kyle Barron <kyle@developmentseed.org>"]
 edition = "2021"
 description = "object_store integration for pyo3."

--- a/pyo3-object_store/README.md
+++ b/pyo3-object_store/README.md
@@ -75,5 +75,6 @@ We don't yet have a _great_ solution here for reusing the store builder type hin
 | 0.9.x             | 0.28               | 0.13               |
 | 0.10.x            | 0.28               | **0.12** :warning: |
 | 0.11.x            | 0.29               | 0.13               |
+| 0.12.x            | 0.29               | 0.14               |
 
 Note that 0.3.x, 0.4.x, and 0.10.x are compatibility releases to use `pyo3-object_store` with older versions of `pyo3` and `object_store`.


### PR DESCRIPTION
Bump version and update changelog