### PR TITLE
fix: strip prefix from `get_opts` result in `MaybePrefixedStore`

### DIFF
--- a/pyo3-object_store/src/prefix.rs
+++ b/pyo3-object_store/src/prefix.rs
@@ -148,7 +148,9 @@ impl<T: ObjectStore> ObjectStore for MaybePrefixedStore<T> {
 
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
         let full_path = self.full_path(location);
-        self.inner.get_opts(&full_path, options).await
+        let mut result = self.inner.get_opts(&full_path, options).await?;
+        result.meta = self.strip_meta(result.meta);
+        Ok(result)
     }
 
     async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> Result<Vec<Bytes>> {


### PR DESCRIPTION
Fixes #744.

`MaybePrefixedStore::get_opts` returned an `ObjectMeta` whose `location` still carried the store prefix, unlike `list`/`list_with_delimiter` (which `strip_meta`). Since `head` delegates to `get_opts`, and the buffered reader (`open_reader`) issues its follow-up range read against the returned `meta.location`, reads on a store with a `prefix=` resolved at `prefix/prefix/key` and 404'd.

This mirrors object_store's own fix for the same issue in its `PrefixStore` ([apache/arrow-rs-object-store#686](https://github.com/apache/arrow-rs-object-store/pull/686)) — the copy vendored here predates it.

Kept to the one-line fix to match the crate's current lack of tests; #744 has a standalone `uv run` repro. Happy to add a regression test if you'd like one.

---

🤖 Investigated and drafted with [Claude Code](https://claude.com/claude-code); reviewed by me.
