### PR TITLE
perf: Reduce memory overhead for multipart uploads

### DIFF
--- a/obstore/python/obstore/_put.pyi
+++ b/obstore/python/obstore/_put.pyi
@@ -109,7 +109,7 @@ def put(
     tags: dict[str, str] | None = None,
     mode: PutMode | None = None,
     use_multipart: bool | None = None,
-    chunk_size: int = 5242880,
+    chunk_size: int = 5 * 1024 * 1024,
     max_concurrency: int = 12,
 ) -> PutResult:
     """Save the provided bytes to the specified location.
@@ -179,7 +179,7 @@ async def put_async(
     tags: dict[str, str] | None = None,
     mode: PutMode | None = None,
     use_multipart: bool | None = None,
-    chunk_size: int = 5242880,
+    chunk_size: int = 5 * 1024 * 1024,
     max_concurrency: int = 12,
 ) -> PutResult:
     """Call `put` asynchronously.

--- a/obstore/python/obstore/_put.pyi
+++ b/obstore/python/obstore/_put.pyi
@@ -109,7 +109,7 @@ def put(
     tags: dict[str, str] | None = None,
     mode: PutMode | None = None,
     use_multipart: bool | None = None,
-    chunk_size: int = ...,
+    chunk_size: int = 5242880,
     max_concurrency: int = 12,
 ) -> PutResult:
     """Save the provided bytes to the specified location.
@@ -179,7 +179,7 @@ async def put_async(
     tags: dict[str, str] | None = None,
     mode: PutMode | None = None,
     use_multipart: bool | None = None,
-    chunk_size: int = ...,
+    chunk_size: int = 5242880,
     max_concurrency: int = 12,
 ) -> PutResult:
     """Call `put` asynchronously.

--- a/obstore/src/put.rs
+++ b/obstore/src/put.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufReader, Read, Seek, SeekFrom};
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -77,8 +78,8 @@ impl PullSource {
     }
 
     /// Whether to use multipart uploads.
-    fn use_multipart(&mut self, chunk_size: usize) -> PyObjectStoreResult<bool> {
-        Ok(self.nbytes()? > chunk_size)
+    fn use_multipart(&mut self, chunk_size: NonZeroUsize) -> PyObjectStoreResult<bool> {
+        Ok(self.nbytes()? > chunk_size.get())
     }
 }
 
@@ -211,9 +212,9 @@ pub(crate) enum PutInput {
 
 impl PutInput {
     /// Whether to use multipart uploads.
-    fn use_multipart(&mut self, chunk_size: usize) -> PyObjectStoreResult<bool> {
+    fn use_multipart(&mut self, chunk_size: NonZeroUsize) -> PyObjectStoreResult<bool> {
         match self {
-            Self::Buffer(buffer) => Ok(buffer.len() > chunk_size),
+            Self::Buffer(buffer) => Ok(buffer.len() > chunk_size.get()),
             Self::Pull(pull_source) => pull_source.use_multipart(chunk_size),
             // We always use multipart uploads for push-based sources because we have no way of
             // knowing how large they'll be and we don't want to buffer them into memory.
@@ -298,7 +299,7 @@ impl<'py> IntoPyObject<'py> for PyPutResult {
 }
 
 #[pyfunction]
-#[pyo3(signature = (store, path, file, *, attributes=None, tags=None, mode=None, use_multipart=None, chunk_size=5242880, max_concurrency=12))]
+#[pyo3(signature = (store, path, file, *, attributes=None, tags=None, mode=None, use_multipart=None, chunk_size=NonZeroUsize::new(5242880).unwrap(), max_concurrency=12))]
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn put(
     py: Python,
@@ -309,7 +310,7 @@ pub(crate) fn put(
     tags: Option<PyTagSet>,
     mode: Option<PyPutMode>,
     use_multipart: Option<bool>,
-    chunk_size: usize,
+    chunk_size: NonZeroUsize,
     max_concurrency: usize,
 ) -> PyObjectStoreResult<PyPutResult> {
     if matches!(file, PutInput::AsyncPush(_)) {
@@ -357,7 +358,7 @@ pub(crate) fn put(
 }
 
 #[pyfunction]
-#[pyo3(signature = (store, path, file, *, attributes=None, tags=None, mode=None, use_multipart=None, chunk_size=5242880, max_concurrency=12))]
+#[pyo3(signature = (store, path, file, *, attributes=None, tags=None, mode=None, use_multipart=None, chunk_size=NonZeroUsize::new(5242880).unwrap(), max_concurrency=12))]
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn put_async(
     py: Python,
@@ -368,7 +369,7 @@ pub(crate) fn put_async(
     tags: Option<PyTagSet>,
     mode: Option<PyPutMode>,
     use_multipart: Option<bool>,
-    chunk_size: usize,
+    chunk_size: NonZeroUsize,
     max_concurrency: usize,
 ) -> PyResult<Bound<PyAny>> {
     let mut use_multipart = if let Some(use_multipart) = use_multipart {
@@ -439,7 +440,7 @@ async fn put_multipart_inner(
     store: Arc<dyn ObjectStore>,
     path: &Path,
     reader: PutInput,
-    chunk_size: usize,
+    chunk_size: NonZeroUsize,
     max_concurrency: usize,
     attributes: Option<PyAttributes>,
     tags: Option<PyTagSet>,
@@ -454,7 +455,7 @@ async fn put_multipart_inner(
     }
 
     let upload = store.put_multipart_opts(path, opts).await?;
-    let mut writer = WriteMultipart::new_with_chunk_size(upload, chunk_size);
+    let mut writer = WriteMultipart::new_with_chunk_size(upload, chunk_size.get());
 
     // Make sure to call abort if the multipart upload failed for any reason
     match write_multipart(&mut writer, reader, chunk_size, max_concurrency).await {
@@ -469,21 +470,21 @@ async fn put_multipart_inner(
 async fn write_multipart(
     writer: &mut WriteMultipart,
     reader: PutInput,
-    chunk_size: usize,
+    chunk_size: NonZeroUsize,
     max_concurrency: usize,
 ) -> PyObjectStoreResult<()> {
     match reader {
         PutInput::Buffer(buffer) => {
             let mut offset = 0;
             while offset < buffer.len() {
-                let end = (offset + chunk_size).min(buffer.len());
+                let end = (offset + chunk_size.get()).min(buffer.len());
                 writer.wait_for_capacity(max_concurrency).await?;
                 writer.put(buffer.slice(offset..end));
                 offset = end;
             }
         }
         PutInput::Pull(mut pull_reader) => {
-            let mut scratch_buffer = vec![0; chunk_size];
+            let mut scratch_buffer = vec![0; chunk_size.get()];
             loop {
                 let read_size = pull_reader.read(&mut scratch_buffer)?;
                 if read_size == 0 {

--- a/obstore/src/put.rs
+++ b/obstore/src/put.rs
@@ -479,10 +479,11 @@ async fn write_multipart(
     match reader {
         PutInput::Pull(mut pull_reader) => loop {
             let mut scratch_buffer = vec![0; chunk_size];
-            let read_size = pull_reader.read(&mut scratch_buffer)?;
-            if read_size == 0 {
-                break;
-            } else {
+            loop {
+                let read_size = pull_reader.read(&mut scratch_buffer)?;
+                if read_size == 0 {
+                    break;
+                }
                 writer.wait_for_capacity(max_concurrency).await?;
                 writer.write(&scratch_buffer[0..read_size]);
             }

--- a/obstore/src/put.rs
+++ b/obstore/src/put.rs
@@ -11,7 +11,7 @@ use object_store::{
     ObjectStore, PutMode, PutMultipartOptions, PutOptions, PutPayload, PutResult, UpdateVersion,
     WriteMultipart,
 };
-use pyo3::exceptions::{PyStopAsyncIteration, PyStopIteration, PyValueError};
+use pyo3::exceptions::{PyOverflowError, PyStopAsyncIteration, PyStopIteration, PyValueError};
 use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedStr;
 use pyo3::types::PyDict;
@@ -475,19 +475,38 @@ async fn write_multipart(
     chunk_size: usize,
     max_concurrency: usize,
 ) -> PyObjectStoreResult<()> {
-    // Match across pull, push, async push
     match reader {
-        PutInput::Pull(mut pull_reader) => loop {
-            let mut scratch_buffer = vec![0; chunk_size];
-            loop {
-                let read_size = pull_reader.read(&mut scratch_buffer)?;
-                if read_size == 0 {
-                    break;
+        PutInput::Pull(mut pull_reader) => {
+            match pull_reader {
+                // For an in-memory buffer, we don't need to read out into a scratch buffer and
+                // thus we don't require any memory overhead from the scratch buffer
+                PullSource::Buffer(cursor) => {
+                    let start = usize::try_from(cursor.position()).map_err(|err| {
+                        PyOverflowError::new_err(format!("Buffer position is too large: {err}"))
+                    })?;
+
+                    let buffer = cursor.into_inner();
+                    let mut offset = start.min(buffer.len());
+                    while offset < buffer.len() {
+                        let end = (offset + chunk_size).min(buffer.len());
+                        writer.wait_for_capacity(max_concurrency).await?;
+                        writer.put(buffer.slice(offset..end));
+                        offset = end;
+                    }
                 }
-                writer.wait_for_capacity(max_concurrency).await?;
-                writer.write(&scratch_buffer[0..read_size]);
+                _ => {
+                    let mut scratch_buffer = vec![0; chunk_size];
+                    loop {
+                        let read_size = pull_reader.read(&mut scratch_buffer)?;
+                        if read_size == 0 {
+                            break;
+                        }
+                        writer.wait_for_capacity(max_concurrency).await?;
+                        writer.write(&scratch_buffer[0..read_size]);
+                    }
+                }
             }
-        },
+        }
         PutInput::SyncPush(push_reader) => {
             for buf in push_reader {
                 writer.wait_for_capacity(max_concurrency).await?;

--- a/obstore/src/put.rs
+++ b/obstore/src/put.rs
@@ -481,8 +481,11 @@ async fn write_multipart(
                 // For an in-memory buffer, we don't need to read out into a scratch buffer and
                 // thus we don't require any memory overhead from the scratch buffer
                 PullSource::Buffer(cursor) => {
-                    let start = usize::try_from(cursor.position()).map_err(|err| {
-                        PyOverflowError::new_err(format!("Buffer position is too large: {err}"))
+                    let start = usize::try_from(cursor.position()).map_err(|_| {
+                        PyOverflowError::new_err(format!(
+                            "Buffer position {} is too large for this platform's usize",
+                            cursor.position()
+                        ))
                     })?;
 
                     let buffer = cursor.into_inner();

--- a/obstore/src/put.rs
+++ b/obstore/src/put.rs
@@ -213,10 +213,11 @@ impl PutInput {
     /// Whether to use multipart uploads.
     fn use_multipart(&mut self, chunk_size: usize) -> PyObjectStoreResult<bool> {
         match self {
+            Self::Buffer(cursor) => Ok(cursor.get_ref().len() > chunk_size),
             Self::Pull(pull_source) => pull_source.use_multipart(chunk_size),
             // We always use multipart uploads for push-based sources because we have no way of
             // knowing how large they'll be and we don't want to buffer them into memory.
-            _ => Ok(true),
+            Self::SyncPush(_) | Self::AsyncPush(_) => Ok(true),
         }
     }
 

--- a/obstore/src/put.rs
+++ b/obstore/src/put.rs
@@ -65,7 +65,6 @@ impl<'py> FromPyObject<'_, 'py> for PyUpdateVersion {
 pub(crate) enum PullSource {
     File(BufReader<File>),
     FileLike(PyFileLikeObject),
-    Buffer(Cursor<Bytes>),
 }
 
 impl PullSource {
@@ -88,7 +87,6 @@ impl Read for PullSource {
         match self {
             Self::File(f) => f.read(buf),
             Self::FileLike(f) => f.read(buf),
-            Self::Buffer(f) => f.read(buf),
         }
     }
 }
@@ -98,7 +96,6 @@ impl Seek for PullSource {
         match self {
             Self::File(f) => f.seek(pos),
             Self::FileLike(f) => f.seek(pos),
-            Self::Buffer(f) => f.seek(pos),
         }
     }
 }
@@ -199,6 +196,9 @@ impl AsyncPushSource {
 
 // #[derive(Debug)]
 pub(crate) enum PutInput {
+    /// A buffer protocol object
+    Buffer(Cursor<Bytes>),
+
     /// Input that we can pull from
     Pull(PullSource),
 
@@ -222,14 +222,12 @@ impl PutInput {
 
     async fn read_all(&mut self) -> PyObjectStoreResult<PutPayload> {
         match self {
-            Self::Pull(pull_source) => match pull_source {
-                PullSource::Buffer(buffer) => Ok(buffer.get_ref().clone().into()),
-                source => {
-                    let mut buf = Vec::new();
-                    source.read_to_end(&mut buf)?;
-                    Ok(Bytes::from(buf).into())
-                }
-            },
+            Self::Buffer(buffer) => Ok(buffer.get_ref().clone().into()),
+            Self::Pull(pull_source) => {
+                let mut buf = Vec::new();
+                pull_source.read_to_end(&mut buf)?;
+                Ok(Bytes::from(buf).into())
+            }
             Self::SyncPush(push_source) => push_source.read_all(),
             Self::AsyncPush(push_source) => push_source.read_all().await,
         }
@@ -246,9 +244,7 @@ impl<'py> FromPyObject<'_, 'py> for PutInput {
                 path,
             )?))))
         } else if let Ok(buffer) = obj.extract::<PyBytes>() {
-            Ok(Self::Pull(PullSource::Buffer(Cursor::new(
-                buffer.into_inner(),
-            ))))
+            Ok(Self::Buffer(Cursor::new(buffer.into_inner())))
         }
         // Check for file-like object
         else if obj.hasattr(intern!(py, "read"))? && obj.hasattr(intern!(py, "seek"))? {
@@ -476,38 +472,32 @@ async fn write_multipart(
     max_concurrency: usize,
 ) -> PyObjectStoreResult<()> {
     match reader {
-        PutInput::Pull(mut pull_reader) => {
-            match pull_reader {
-                // For an in-memory buffer, we don't need to read out into a scratch buffer and
-                // thus we don't require any memory overhead from the scratch buffer
-                PullSource::Buffer(cursor) => {
-                    let start = usize::try_from(cursor.position()).map_err(|_| {
-                        PyOverflowError::new_err(format!(
-                            "Buffer position {} is too large for this platform's usize",
-                            cursor.position()
-                        ))
-                    })?;
+        PutInput::Buffer(cursor) => {
+            let start = usize::try_from(cursor.position()).map_err(|_| {
+                PyOverflowError::new_err(format!(
+                    "Buffer position {} is too large for this platform's usize",
+                    cursor.position()
+                ))
+            })?;
 
-                    let buffer = cursor.into_inner();
-                    let mut offset = start.min(buffer.len());
-                    while offset < buffer.len() {
-                        let end = (offset + chunk_size).min(buffer.len());
-                        writer.wait_for_capacity(max_concurrency).await?;
-                        writer.put(buffer.slice(offset..end));
-                        offset = end;
-                    }
+            let buffer = cursor.into_inner();
+            let mut offset = start.min(buffer.len());
+            while offset < buffer.len() {
+                let end = (offset + chunk_size).min(buffer.len());
+                writer.wait_for_capacity(max_concurrency).await?;
+                writer.put(buffer.slice(offset..end));
+                offset = end;
+            }
+        }
+        PutInput::Pull(mut pull_reader) => {
+            let mut scratch_buffer = vec![0; chunk_size];
+            loop {
+                let read_size = pull_reader.read(&mut scratch_buffer)?;
+                if read_size == 0 {
+                    break;
                 }
-                _ => {
-                    let mut scratch_buffer = vec![0; chunk_size];
-                    loop {
-                        let read_size = pull_reader.read(&mut scratch_buffer)?;
-                        if read_size == 0 {
-                            break;
-                        }
-                        writer.wait_for_capacity(max_concurrency).await?;
-                        writer.write(&scratch_buffer[0..read_size]);
-                    }
-                }
+                writer.wait_for_capacity(max_concurrency).await?;
+                writer.write(&scratch_buffer[0..read_size]);
             }
         }
         PutInput::SyncPush(push_reader) => {

--- a/obstore/src/put.rs
+++ b/obstore/src/put.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::{BufReader, Cursor, Read, Seek, SeekFrom};
+use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -11,7 +11,7 @@ use object_store::{
     ObjectStore, PutMode, PutMultipartOptions, PutOptions, PutPayload, PutResult, UpdateVersion,
     WriteMultipart,
 };
-use pyo3::exceptions::{PyOverflowError, PyStopAsyncIteration, PyStopIteration, PyValueError};
+use pyo3::exceptions::{PyStopAsyncIteration, PyStopIteration, PyValueError};
 use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedStr;
 use pyo3::types::PyDict;
@@ -197,7 +197,7 @@ impl AsyncPushSource {
 // #[derive(Debug)]
 pub(crate) enum PutInput {
     /// A buffer protocol object
-    Buffer(Cursor<Bytes>),
+    Buffer(Bytes),
 
     /// Input that we can pull from
     Pull(PullSource),
@@ -213,7 +213,7 @@ impl PutInput {
     /// Whether to use multipart uploads.
     fn use_multipart(&mut self, chunk_size: usize) -> PyObjectStoreResult<bool> {
         match self {
-            Self::Buffer(cursor) => Ok(cursor.get_ref().len() > chunk_size),
+            Self::Buffer(buffer) => Ok(buffer.len() > chunk_size),
             Self::Pull(pull_source) => pull_source.use_multipart(chunk_size),
             // We always use multipart uploads for push-based sources because we have no way of
             // knowing how large they'll be and we don't want to buffer them into memory.
@@ -223,7 +223,7 @@ impl PutInput {
 
     async fn read_all(&mut self) -> PyObjectStoreResult<PutPayload> {
         match self {
-            Self::Buffer(buffer) => Ok(buffer.get_ref().clone().into()),
+            Self::Buffer(buffer) => Ok(buffer.clone().into()),
             Self::Pull(pull_source) => {
                 let mut buf = Vec::new();
                 pull_source.read_to_end(&mut buf)?;
@@ -245,7 +245,7 @@ impl<'py> FromPyObject<'_, 'py> for PutInput {
                 path,
             )?))))
         } else if let Ok(buffer) = obj.extract::<PyBytes>() {
-            Ok(Self::Buffer(Cursor::new(buffer.into_inner())))
+            Ok(Self::Buffer(buffer.into_inner()))
         }
         // Check for file-like object
         else if obj.hasattr(intern!(py, "read"))? && obj.hasattr(intern!(py, "seek"))? {
@@ -473,16 +473,8 @@ async fn write_multipart(
     max_concurrency: usize,
 ) -> PyObjectStoreResult<()> {
     match reader {
-        PutInput::Buffer(cursor) => {
-            let start = usize::try_from(cursor.position()).map_err(|_| {
-                PyOverflowError::new_err(format!(
-                    "Buffer position {} is too large for this platform's usize",
-                    cursor.position()
-                ))
-            })?;
-
-            let buffer = cursor.into_inner();
-            let mut offset = start.min(buffer.len());
+        PutInput::Buffer(buffer) => {
+            let mut offset = 0;
             while offset < buffer.len() {
                 let end = (offset + chunk_size).min(buffer.len());
                 writer.wait_for_capacity(max_concurrency).await?;

--- a/obstore/src/put.rs
+++ b/obstore/src/put.rs
@@ -299,7 +299,7 @@ impl<'py> IntoPyObject<'py> for PyPutResult {
 }
 
 #[pyfunction]
-#[pyo3(signature = (store, path, file, *, attributes=None, tags=None, mode=None, use_multipart=None, chunk_size=NonZeroUsize::new(5242880).unwrap(), max_concurrency=12))]
+#[pyo3(signature = (store, path, file, *, attributes=None, tags=None, mode=None, use_multipart=None, chunk_size=NonZeroUsize::new(5 * 1024 * 1024).unwrap(), max_concurrency=12))]
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn put(
     py: Python,
@@ -358,7 +358,7 @@ pub(crate) fn put(
 }
 
 #[pyfunction]
-#[pyo3(signature = (store, path, file, *, attributes=None, tags=None, mode=None, use_multipart=None, chunk_size=NonZeroUsize::new(5242880).unwrap(), max_concurrency=12))]
+#[pyo3(signature = (store, path, file, *, attributes=None, tags=None, mode=None, use_multipart=None, chunk_size=NonZeroUsize::new(5 * 1024 * 1024).unwrap(), max_concurrency=12))]
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn put_async(
     py: Python,

--- a/tests/test_put.py
+++ b/tests/test_put.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools
 from tempfile import TemporaryDirectory
 
@@ -109,3 +111,53 @@ def test_put_sync_iterable_local_store():
         store.put(path, iterator)
 
         assert store.get(path).bytes() == data
+
+
+CHUNK_SIZE = 1024
+
+
+@pytest.mark.parametrize("nbytes", [0, 1, CHUNK_SIZE - 1, CHUNK_SIZE, CHUNK_SIZE + 1])
+def test_put_multipart_buffer_chunk_boundaries(nbytes: int):
+    """Buffers are chunked correctly regardless of alignment to chunk_size."""
+    store = MemoryStore()
+    data = bytes(range(256)) * (nbytes // 256 + 1)
+    data = data[:nbytes]
+
+    store.put("file1.txt", data, use_multipart=True, chunk_size=CHUNK_SIZE)
+
+    assert store.get("file1.txt").bytes() == data
+
+
+@pytest.mark.parametrize("wrapper", [bytes, bytearray, memoryview])
+def test_put_multipart_buffer_types(
+    wrapper: type[bytes | bytearray | memoryview],
+):
+    """Any buffer-protocol input is uploaded verbatim."""
+    store = MemoryStore()
+    data = b"the quick brown fox jumps over the lazy dog," * 500
+
+    store.put("file1.txt", wrapper(data), use_multipart=True, chunk_size=CHUNK_SIZE)
+
+    assert store.get("file1.txt").bytes() == data
+
+
+def test_put_multipart_buffer_slice():
+    """A memoryview into the middle of a larger buffer uploads only its own bytes."""
+    store = MemoryStore()
+    backing = bytes(range(256)) * 40
+    view = memoryview(backing)[1000:8000]
+
+    store.put("file1.txt", view, use_multipart=True, chunk_size=CHUNK_SIZE)
+
+    assert store.get("file1.txt").bytes() == backing[1000:8000]
+
+
+def test_put_multipart_buffer_local_store():
+    """The buffer multipart path round-trips through a store with real parts."""
+    with TemporaryDirectory() as tmpdir:
+        store = LocalStore(tmpdir)
+        data = b"the quick brown fox jumps over the lazy dog," * 500
+
+        store.put("big-data.txt", data, use_multipart=True, chunk_size=CHUNK_SIZE)
+
+        assert store.get("big-data.txt").bytes() == data


### PR DESCRIPTION
As described well in #767, we currently _always_ copy input into a scratch buffer for any pull source. But for buffer sources this is unnecessary as we can upload the input buffer directly.

### Change list

- Make `Buffer` a first-class variant of `PutInput`, rather than shoe-horning it into a `PullSource`. Also we no longer need to use a `Cursor` wrapping the `Buffer`.
- Don't use a scratch buffer copy when uploading a buffer
- For a pull source, create a _single_ scratch buffer _outside_ the loop, which we reuse on each iteration, rather than creating a new buffer allocation in every loop iteration.

This PR was created in discussion with Claude but I wrote the source code changes myself. Claude wrote the new tests.

Closes #767 